### PR TITLE
Fixed instruction output of [value at memory location]

### DIFF
--- a/lib/Target/DCPU16/InstPrinter/DCPU16InstPrinter.cpp
+++ b/lib/Target/DCPU16/InstPrinter/DCPU16InstPrinter.cpp
@@ -70,10 +70,7 @@ void DCPU16InstPrinter::printSrcMemOperand(const MCInst *MI, unsigned OpNo,
   // vs
   //   SET r2, glb(r1) ; The Notch order
   // Otherwise (!) dcpu16-as will silently miscompile the output :(
-  if (!Base.getReg())
-    O << '&';
-  else
-    O << '[';
+  O << '[';
 
   if (Disp.isExpr())
     O << *Disp.getExpr();
@@ -84,7 +81,8 @@ void DCPU16InstPrinter::printSrcMemOperand(const MCInst *MI, unsigned OpNo,
 
   // Print register base field
   if (Base.getReg())
-    O << '+' << getRegisterName(Base.getReg()) << ']';
+    O << '+' << getRegisterName(Base.getReg());
+  O << ']';
 }
 
 void DCPU16InstPrinter::printCCOperand(const MCInst *MI, unsigned OpNo,


### PR DESCRIPTION
Previous: &123 Now: [123]
This should be compatible with the syntax most assemblers use (including
notch's spec)

You can reproduce the previous output by compiling the following snippet with -03 optimization (Haven't found a better example yet...)

``` C
typedef unsigned short Word;

void _memset(Word* loc, Word filler) {
    *loc = filler;
}

int main(void) {
  _memset(0x100, 0x12);
}
```

This will output 
;init, _memset and stuf
.
.
:main
    SET &256, 18 ; The Notch order
    SET X, 0 ; The Notch order
    SET PC, POP ; The Notch order
