### PR TITLE
Changed output of [0+Reg] to [Reg]

### DIFF
--- a/lib/Target/DCPU16/InstPrinter/DCPU16InstPrinter.cpp
+++ b/lib/Target/DCPU16/InstPrinter/DCPU16InstPrinter.cpp
@@ -76,12 +76,19 @@ void DCPU16InstPrinter::printSrcMemOperand(const MCInst *MI, unsigned OpNo,
     O << *Disp.getExpr();
   else {
     assert(Disp.isImm() && "Expected immediate in displacement field");
-    O << Disp.getImm();
+    if(Disp.getImm() != 0) {
+        O << Disp.getImm();
+    }    
   }
 
   // Print register base field
-  if (Base.getReg())
-    O << '+' << getRegisterName(Base.getReg());
+  if (Base.getReg()) {
+    if(Disp.isImm() && Disp.getImm() != 0) {
+      O << '+';
+    }
+    O << getRegisterName(Base.getReg());
+  }
+    
   O << ']';
 }
 


### PR DESCRIPTION
Currently in the readme example assembler output there is the following line: 
SET  [0+C], 0 ; The Notch order
The [0+C] is somewhat problematic as the "official" assembler noted in the readme does not understand this expression, and even if assemblers understand [0+C] it is very likely that they translate it to [Reg+Nextword] which is one one cycle slower and one word longer (kind of micro-optimization though, but it looks cleaner anyway)
I've fixed this in the InstrPrinter but I'm not sure if this is the right place to do so.
