### PR TITLE
DCPU16: enable moves from any register to any

### DIFF
--- a/lib/Target/DCPU16/DCPU16InstrInfo.cpp
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.cpp
@@ -83,10 +83,10 @@ void DCPU16InstrInfo::copyPhysReg(MachineBasicBlock &MBB,
                                   unsigned DestReg, unsigned SrcReg,
                                   bool KillSrc) const {
   unsigned Opc;
-  if (DCPU16::GR16RegClass.contains(DestReg, SrcReg))
-    Opc = DCPU16::MOV16rr;
-  else
-    llvm_unreachable("Impossible reg-to-reg copy");
+  // An interesting aspect of DCPU16 is that all the registers,
+  // including PC, SP and O are valid SET arguments. So, it's
+  // legal to say SET PC, O; It just usually does not make sense.
+  Opc = DCPU16::MOV16rr;
 
   BuildMI(MBB, I, DL, get(Opc), DestReg)
     .addReg(SrcReg, getKillRegState(KillSrc));

--- a/lib/Target/DCPU16/DCPU16InstrInfo.td
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.td
@@ -717,37 +717,43 @@ def CMP16mr : I16mr<0x0,
 let isCommutable = 1 in {
 def BIT16rr : I16rr<0x0,
                     (outs), (ins GR16:$src, GR16:$src2),
-                    "bit.w\t{$src2, $src}",
+                    "IFN\t{$src, $src2} ; The Notch order\n"
+		    "\tSET\tO, 1 ; The Notch order",
                     [(DCPU16cmp (and_su GR16:$src, GR16:$src2), 0),
                      (implicit RO)]>;
 }
 def BIT16ri : I16ri<0x0,
                     (outs), (ins GR16:$src, i16imm:$src2),
-                    "bit.w\t{$src2, $src}",
+                    "IFN\t{$src, $src2} ; The Notch order\n"
+		    "\tSET\tO, 1 ; The Notch order",
                     [(DCPU16cmp (and_su GR16:$src, imm:$src2), 0),
                      (implicit RO)]>;
 
 def BIT16rm : I16rm<0x0,
                     (outs), (ins GR16:$src, memdst:$src2),
-                    "bit.w\t{$src2, $src}",
+                    "IFN\t{$src, $src2} ; The Notch order\n"
+		    "\tSET\tO, 1 ; The Notch order",
                     [(DCPU16cmp (and_su GR16:$src,  (load addr:$src2)), 0),
                      (implicit RO)]>;
 
 def BIT16mr : I16mr<0x0,
                     (outs), (ins memsrc:$src, GR16:$src2),
-                    "bit.w\t{$src2, $src}",
+                    "IFN\t{$src, $src2} ; The Notch order\n"
+		    "\tSET\tO, 1 ; The Notch order",
                     [(DCPU16cmp (and_su (load addr:$src), GR16:$src2), 0),
                      (implicit RO)]>;
 
 def BIT16mi : I16mi<0x0,
                     (outs), (ins memsrc:$src, i16imm:$src2),
-                    "bit.w\t{$src2, $src}",
+                    "IFN\t{$src, $src2} ; The Notch order\n"
+		    "\tSET\tO, 1 ; The Notch order",
                     [(DCPU16cmp (and_su (load addr:$src), (i16 imm:$src2)), 0),
                      (implicit RO)]>;
 
 def BIT16mm : I16mm<0x0,
                     (outs), (ins memsrc:$src, memsrc:$src2),
-                    "bit.w\t{$src2, $src}",
+                    "IFN\t{$src, $src2} ; The Notch order\n"
+		    "\tSET\tO, 1 ; The Notch order",
                     [(DCPU16cmp (and_su (i16 (load addr:$src)),
                                         (load addr:$src2)),
                                  0),

--- a/test/CodeGen/DCPU16/bit.ll
+++ b/test/CodeGen/DCPU16/bit.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
 target datalayout = "e-p:16:16:16-i1:8:8-i8:8:8-i16:16:16-i32:16:32"
 target triple = "dcpu16"
@@ -13,7 +12,7 @@ define i16 @bitwrr(i16 %a, i16 %b) nounwind {
 	ret i16 %t3
 }
 ; CHECK: :bitwrr
-; CHECK: bit.w	r14, r15
+; CHECK: IFN A, B ; The Notch order
 
 define i16 @bitwri(i16 %a) nounwind {
 	%t1 = and i16 %a, 4080
@@ -22,7 +21,7 @@ define i16 @bitwri(i16 %a) nounwind {
 	ret i16 %t3
 }
 ; CHECK: :bitwri
-; CHECK: bit.w	#4080, r15
+; CHECK: IFN A, 4080
 
 define i16 @bitwir(i16 %a) nounwind {
 	%t1 = and i16 4080, %a
@@ -31,7 +30,7 @@ define i16 @bitwir(i16 %a) nounwind {
 	ret i16 %t3
 }
 ; CHECK: :bitwir
-; CHECK: bit.w	#4080, r15
+; CHECK: IFN A, 4080
 
 define i16 @bitwmi() nounwind {
 	%t1 = load i16* @foo16
@@ -41,7 +40,7 @@ define i16 @bitwmi() nounwind {
 	ret i16 %t4
 }
 ; CHECK: :bitwmi
-; CHECK: bit.w	#4080, &foo16
+; CHECK: IFN [foo16], 4080
 
 define i16 @bitwim() nounwind {
 	%t1 = load i16* @foo16
@@ -51,7 +50,7 @@ define i16 @bitwim() nounwind {
 	ret i16 %t4
 }
 ; CHECK: :bitwim
-; CHECK: bit.w	#4080, &foo16
+; CHECK: IFN [foo16], 4080
 
 define i16 @bitwrm(i16 %a) nounwind {
 	%t1 = load i16* @foo16
@@ -61,7 +60,7 @@ define i16 @bitwrm(i16 %a) nounwind {
 	ret i16 %t4
 }
 ; CHECK: :bitwrm
-; CHECK: bit.w	&foo16, r15
+; CHECK: IFN A, [foo16]
 
 define i16 @bitwmr(i16 %a) nounwind {
 	%t1 = load i16* @foo16
@@ -71,7 +70,7 @@ define i16 @bitwmr(i16 %a) nounwind {
 	ret i16 %t4
 }
 ; CHECK: :bitwmr
-; CHECK: bit.w	r15, &foo16
+; CHECK: IFN [foo16], A
 
 define i16 @bitwmm() nounwind {
 	%t1 = load i16* @foo16
@@ -82,5 +81,5 @@ define i16 @bitwmm() nounwind {
 	ret i16 %t5
 }
 ; CHECK: :bitwmm
-; CHECK: bit.w	&bar16, &foo16
+; CHECK: IFN [foo16], [bar16]
 


### PR DESCRIPTION
This commit allows previously disabled moves from/to SP, PC, O and fixes #92.

The implementation of icmp is bad, but I don't know (yet) how to properly implement this. This dept is tracked by #93.

Please, take a look.
