### PR TITLE
More 16bit trickery

### DIFF
--- a/include/llvm/Module.h
+++ b/include/llvm/Module.h
@@ -203,6 +203,7 @@ private:
   std::string ModuleID;           ///< Human readable identifier for the module
   std::string TargetTriple;       ///< Platform target triple Module compiled on
   std::string DataLayout;         ///< Target data description
+  unsigned BitsPerByte;           ///< Number of bits in an addressable byte
   void *NamedMDSymTab;            ///< NamedMDNode names.
 
   friend class Constant;
@@ -229,6 +230,9 @@ public:
   /// the type sizes and alignments expected by this module.
   /// @returns the data layout as a string
   const std::string &getDataLayout() const { return DataLayout; }
+
+  /// Get the number of bits per byte for the module's target platform.
+  const unsigned getBitsPerByte() const { return BitsPerByte; }
 
   /// Get the target triple which is a string describing the target host.
   /// @returns a string containing the target triple.
@@ -259,6 +263,9 @@ public:
 
   /// Set the data layout
   void setDataLayout(StringRef DL) { DataLayout = DL; }
+
+  /// Set the number of bits per byte
+  void setBitsPerByte(unsigned BPB) { BitsPerByte = BPB; }
 
   /// Set the target triple.
   void setTargetTriple(StringRef T) { TargetTriple = T; }

--- a/include/llvm/Target/TargetData.h
+++ b/include/llvm/Target/TargetData.h
@@ -125,9 +125,9 @@ public:
   TargetData();
 
   /// Constructs a TargetData from a specification string. See init().
-  explicit TargetData(StringRef TargetDescription)
+  explicit TargetData(StringRef TargetDescription, unsigned _BitsPerBytes = 8)
     : ImmutablePass(ID) {
-    std::string errMsg = parseSpecifier(TargetDescription, this);
+    std::string errMsg = parseSpecifier(TargetDescription, this, _BitsPerBytes);
     assert(errMsg == "" && "Invalid target data layout string.");
     (void)errMsg;
   }
@@ -135,7 +135,12 @@ public:
   /// Parses a target data specification string. Returns an error message
   /// if the string is malformed, or the empty string on success. Optionally
   /// initialises a TargetData object if passed a non-null pointer.
-  static std::string parseSpecifier(StringRef TargetDescription, TargetData* td = 0);
+  /// It is possible to specify the number of bits that are contained
+  /// in a byte. This will be respected when parsing the TargetDescription
+  /// string. It has a default value of 8.
+  static std::string parseSpecifier(StringRef TargetDescription,
+                                    TargetData* td = 0,
+                                    unsigned BitsPerByte = 8);
 
   /// Initialize target data from properties stored in the module.
   explicit TargetData(const Module *M);
@@ -207,9 +212,7 @@ public:
   unsigned getPointerSize()         const { return PointerMemSize; }
   /// Target pointer size, in bits
   unsigned getPointerSizeInBits()   const {
-    // XXX: this is a dirty hack. it should be multiplied by BitsPerByte,
-    // but that triggers assertions.
-    return 8*PointerMemSize;
+    return BitsPerByte*PointerMemSize;
   }
 
   /// Size examples:

--- a/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -22,6 +22,7 @@
 #include "llvm/DerivedTypes.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetData.h"
 using namespace llvm;
 
 //===----------------------------------------------------------------------===//
@@ -1831,7 +1832,7 @@ void DAGTypeLegalizer::ExpandIntRes_LOAD(LoadSDNode *N,
     EVT NEVT = EVT::getIntegerVT(*DAG.getContext(), ExcessBits);
 
     // Increment the pointer to the other half.
-    unsigned IncrementSize = NVT.getSizeInBits()/8;
+    unsigned IncrementSize = NVT.getSizeInBits()/TLI.getTargetData()->getBitsPerByte();
     Ptr = DAG.getNode(ISD::ADD, dl, Ptr.getValueType(), Ptr,
                       DAG.getIntPtrConstant(IncrementSize));
     Hi = DAG.getExtLoad(ExtType, dl, NVT, Ch, Ptr,
@@ -1848,8 +1849,8 @@ void DAGTypeLegalizer::ExpandIntRes_LOAD(LoadSDNode *N,
     // the cost of some bit-fiddling.
     EVT MemVT = N->getMemoryVT();
     unsigned EBytes = MemVT.getStoreSize();
-    unsigned IncrementSize = NVT.getSizeInBits()/8;
-    unsigned ExcessBits = (EBytes - IncrementSize)*8;
+    unsigned IncrementSize = NVT.getSizeInBits()/TLI.getTargetData()->getBitsPerByte();
+    unsigned ExcessBits = (EBytes - IncrementSize)*TLI.getTargetData()->getBitsPerByte();
 
     // Load both the high bits and maybe some of the low bits.
     Hi = DAG.getExtLoad(ExtType, dl, NVT, Ch, Ptr, N->getPointerInfo(),
@@ -2701,7 +2702,7 @@ SDValue DAGTypeLegalizer::ExpandIntOp_STORE(StoreSDNode *N, unsigned OpNo) {
     EVT NEVT = EVT::getIntegerVT(*DAG.getContext(), ExcessBits);
 
     // Increment the pointer to the other half.
-    unsigned IncrementSize = NVT.getSizeInBits()/8;
+    unsigned IncrementSize = NVT.getSizeInBits()/TLI.getTargetData()->getBitsPerByte();
     Ptr = DAG.getNode(ISD::ADD, dl, Ptr.getValueType(), Ptr,
                       DAG.getIntPtrConstant(IncrementSize));
     Hi = DAG.getTruncStore(Ch, dl, Hi, Ptr,
@@ -2717,8 +2718,8 @@ SDValue DAGTypeLegalizer::ExpandIntOp_STORE(StoreSDNode *N, unsigned OpNo) {
 
   EVT ExtVT = N->getMemoryVT();
   unsigned EBytes = ExtVT.getStoreSize();
-  unsigned IncrementSize = NVT.getSizeInBits()/8;
-  unsigned ExcessBits = (EBytes - IncrementSize)*8;
+  unsigned IncrementSize = NVT.getSizeInBits()/TLI.getTargetData()->getBitsPerByte();
+  unsigned ExcessBits = (EBytes - IncrementSize)*TLI.getTargetData()->getBitsPerByte();
   EVT HiVT = EVT::getIntegerVT(*DAG.getContext(),
                                ExtVT.getSizeInBits() - ExcessBits);
 

--- a/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -591,7 +591,7 @@ TargetLowering::TargetLowering(const TargetMachine &tm,
   setOperationAction(ISD::TRAP, MVT::Other, Expand);
 
   IsLittleEndian = TD->isLittleEndian();
-  PointerTy = MVT::getIntegerVT(8*TD->getPointerSize());
+  PointerTy = MVT::getIntegerVT(TD->getPointerSizeInBits());
   memset(RegClassForVT, 0,MVT::LAST_VALUETYPE*sizeof(TargetRegisterClass*));
   memset(TargetDAGCombineArray, 0, array_lengthof(TargetDAGCombineArray));
   maxStoresPerMemset = maxStoresPerMemcpy = maxStoresPerMemmove = 8;
@@ -629,7 +629,7 @@ TargetLowering::~TargetLowering() {
 }
 
 MVT TargetLowering::getShiftAmountTy(EVT LHSTy) const {
-  return MVT::getIntegerVT(8*TD->getPointerSize());
+  return MVT::getIntegerVT(TD->getPointerSizeInBits());
 }
 
 /// canOpTrap - Returns true if the operation can trap for the value type.
@@ -2914,7 +2914,7 @@ TargetLowering::AsmOperandInfoVector TargetLowering::ParseConstraints(
           break;
         }
       } else if (dyn_cast<PointerType>(OpTy)) {
-        OpInfo.ConstraintVT = MVT::getIntegerVT(8*TD->getPointerSize());
+        OpInfo.ConstraintVT = MVT::getIntegerVT(TD->getPointerSizeInBits());
       } else {
         OpInfo.ConstraintVT = EVT::getEVT(OpTy, true);
       }

--- a/lib/Linker/LinkModules.cpp
+++ b/lib/Linker/LinkModules.cpp
@@ -1157,8 +1157,10 @@ bool ModuleLinker::run() {
 
   // Inherit the target data from the source module if the destination module
   // doesn't have one already.
-  if (DstM->getDataLayout().empty() && !SrcM->getDataLayout().empty())
+  if (DstM->getDataLayout().empty() && !SrcM->getDataLayout().empty()) {
     DstM->setDataLayout(SrcM->getDataLayout());
+    DstM->setBitsPerByte(SrcM->getBitsPerByte());
+  }
 
   // Copy the target triple from the source to dest if the dest's is empty.
   if (DstM->getTargetTriple().empty() && !SrcM->getTargetTriple().empty())

--- a/lib/Target/DCPU16/DCPU16ISelLowering.cpp
+++ b/lib/Target/DCPU16/DCPU16ISelLowering.cpp
@@ -62,41 +62,72 @@ DCPU16TargetLowering::DCPU16TargetLowering(DCPU16TargetMachine &tm) :
   setLoadExtAction(ISD::EXTLOAD,  MVT::i1,  Promote);
   setLoadExtAction(ISD::SEXTLOAD, MVT::i1,  Promote);
   setLoadExtAction(ISD::ZEXTLOAD, MVT::i1,  Promote);
-  setLoadExtAction(ISD::SEXTLOAD, MVT::i16, Expand);
+  setLoadExtAction(ISD::SEXTLOAD, MVT::i8,  Expand);
+  setLoadExtAction(ISD::SEXTLOAD, MVT::i32, Expand);
 
+  setOperationAction(ISD::SRA,              MVT::i8,    Promote);
+  setOperationAction(ISD::SHL,              MVT::i8,    Promote);
+  setOperationAction(ISD::SRL,              MVT::i8,    Promote);
+  setOperationAction(ISD::ROTL,             MVT::i8,    Promote);
+  setOperationAction(ISD::ROTR,             MVT::i8,    Promote);
   setOperationAction(ISD::ROTL,             MVT::i16,   Expand);
   setOperationAction(ISD::ROTR,             MVT::i16,   Expand);
+  setOperationAction(ISD::BSWAP,            MVT::i8,    Promote);
   setOperationAction(ISD::BSWAP,            MVT::i16,   Expand);
   setOperationAction(ISD::GlobalAddress,    MVT::i16,   Custom);
   setOperationAction(ISD::ExternalSymbol,   MVT::i16,   Custom);
   setOperationAction(ISD::BlockAddress,     MVT::i16,   Custom);
   setOperationAction(ISD::BR_JT,            MVT::Other, Expand);
+  setOperationAction(ISD::BR_CC,            MVT::i8,    Promote);
   setOperationAction(ISD::BR_CC,            MVT::i16,   Custom);
   setOperationAction(ISD::BRCOND,           MVT::Other, Expand);
+  setOperationAction(ISD::SETCC,            MVT::i8,    Promote);
   setOperationAction(ISD::SETCC,            MVT::i16,   Expand);
+  setOperationAction(ISD::SELECT,           MVT::i8,    Promote);
   setOperationAction(ISD::SELECT,           MVT::i16,   Expand);
+  setOperationAction(ISD::SELECT_CC,        MVT::i8,    Promote);
   setOperationAction(ISD::SELECT_CC,        MVT::i16,   Custom);
   setOperationAction(ISD::SIGN_EXTEND,      MVT::i16,   Custom);
+  setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i8,  Promote);
   setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i16, Expand);
 
+  setOperationAction(ISD::CTTZ,             MVT::i8,    Promote);
   setOperationAction(ISD::CTTZ,             MVT::i16,   Expand);
+  setOperationAction(ISD::CTTZ_ZERO_UNDEF,  MVT::i8,    Promote);
   setOperationAction(ISD::CTTZ_ZERO_UNDEF,  MVT::i16,   Expand);
+  setOperationAction(ISD::CTLZ,             MVT::i8,    Promote);
   setOperationAction(ISD::CTLZ,             MVT::i16,   Expand);
+  setOperationAction(ISD::CTLZ_ZERO_UNDEF,  MVT::i8,    Promote);
   setOperationAction(ISD::CTLZ_ZERO_UNDEF,  MVT::i16,   Expand);
+  setOperationAction(ISD::CTPOP,            MVT::i8,    Promote);
   setOperationAction(ISD::CTPOP,            MVT::i16,   Expand);
 
+  setOperationAction(ISD::SHL_PARTS,        MVT::i8,    Promote);
   setOperationAction(ISD::SHL_PARTS,        MVT::i16,   Expand);
+  setOperationAction(ISD::SRL_PARTS,        MVT::i8,    Promote);
   setOperationAction(ISD::SRL_PARTS,        MVT::i16,   Expand);
+  setOperationAction(ISD::SRA_PARTS,        MVT::i8,    Promote);
   setOperationAction(ISD::SRA_PARTS,        MVT::i16,   Expand);
 
   setOperationAction(ISD::SIGN_EXTEND_INREG, MVT::i1,   Expand);
 
   // FIXME: Implement efficiently multiplication by a constant
+  setOperationAction(ISD::MUL,              MVT::i8,    Promote);
+  setOperationAction(ISD::MULHS,            MVT::i8,    Promote);
+  setOperationAction(ISD::MULHU,            MVT::i8,    Promote);
+  setOperationAction(ISD::SMUL_LOHI,        MVT::i8,    Promote);
+  setOperationAction(ISD::UMUL_LOHI,        MVT::i8,    Promote);
   setOperationAction(ISD::MULHS,            MVT::i16,   Expand);
   setOperationAction(ISD::MULHU,            MVT::i16,   Expand);
   setOperationAction(ISD::SMUL_LOHI,        MVT::i16,   Expand);
   setOperationAction(ISD::UMUL_LOHI,        MVT::i16,   Expand);
 
+  setOperationAction(ISD::UDIV,             MVT::i8,    Promote);
+  setOperationAction(ISD::UDIVREM,          MVT::i8,    Promote);
+  setOperationAction(ISD::UREM,             MVT::i8,    Promote);
+  setOperationAction(ISD::SDIV,             MVT::i8,    Promote);
+  setOperationAction(ISD::SDIVREM,          MVT::i8,    Promote);
+  setOperationAction(ISD::SREM,             MVT::i8,    Promote);
   setOperationAction(ISD::UDIVREM,          MVT::i16,   Expand);
   setOperationAction(ISD::SDIV,             MVT::i16,   Expand);
   setOperationAction(ISD::SDIVREM,          MVT::i16,   Expand);

--- a/lib/Target/DCPU16/DCPU16TargetMachine.cpp
+++ b/lib/Target/DCPU16/DCPU16TargetMachine.cpp
@@ -35,7 +35,7 @@ DCPU16TargetMachine::DCPU16TargetMachine(const Target &T,
   : LLVMTargetMachine(T, TT, CPU, FS, Options, RM, CM, OL),
     Subtarget(TT, CPU, FS),
     // FIXME: Check TargetData string.
-    DataLayout("e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16-W"),
+    DataLayout("e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16-B16"),
     InstrInfo(*this), TLInfo(*this), TSInfo(*this),
     FrameLowering(Subtarget) { }
 

--- a/lib/Target/DCPU16/DCPU16TargetMachine.cpp
+++ b/lib/Target/DCPU16/DCPU16TargetMachine.cpp
@@ -35,7 +35,7 @@ DCPU16TargetMachine::DCPU16TargetMachine(const Target &T,
   : LLVMTargetMachine(T, TT, CPU, FS, Options, RM, CM, OL),
     Subtarget(TT, CPU, FS),
     // FIXME: Check TargetData string.
-    DataLayout("e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16-B16"),
+    DataLayout("e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16", 16),
     InstrInfo(*this), TLInfo(*this), TSInfo(*this),
     FrameLowering(Subtarget) { }
 

--- a/lib/Target/TargetData.cpp
+++ b/lib/Target/TargetData.cpp
@@ -313,7 +313,7 @@ TargetData::TargetData() : ImmutablePass(ID) {
 
 TargetData::TargetData(const Module *M)
   : ImmutablePass(ID) {
-  std::string errMsg = parseSpecifier(M->getDataLayout(), this);
+  std::string errMsg = parseSpecifier(M->getDataLayout(), this, M->getBitsPerByte());
   assert(errMsg == "" && "Module M has malformed target data layout string.");
   (void)errMsg;
 }

--- a/lib/Target/TargetData.cpp
+++ b/lib/Target/TargetData.cpp
@@ -46,6 +46,7 @@ StructLayout::StructLayout(StructType *ST, const TargetData &TD) {
   StructAlignment = 0;
   StructSize = 0;
   NumElements = ST->getNumElements();
+  BitsPerByte = TD.getBitsPerByte();
 
   // Loop over each of the elements, placing them in memory.
   for (unsigned i = 0, e = NumElements; i != e; ++i) {
@@ -136,7 +137,7 @@ void TargetData::init() {
 
   LayoutMap = 0;
   LittleEndian = false;
-  WordAddressing = false;
+  BitsPerByte = 8;
   PointerMemSize = 8;
   PointerABIAlign = 8;
   PointerPrefAlign = PointerABIAlign;
@@ -177,9 +178,14 @@ std::string TargetData::parseSpecifier(StringRef Desc, TargetData *td) {
     assert(!Specifier.empty() && "Can't be empty here");
 
     switch (Specifier[0]) {
-    case 'W': {
-    	td->WordAddressing = true;
-    	break;
+    case 'B': {
+      Specifier = Specifier.substr(1);
+      int BitsPerByte = getInt(Specifier);
+      if (BitsPerByte < 0 || BitsPerByte % 8 != 0)
+        return "invalid number of bits per byte, must be a positive 8-bit multiple";
+      if (td)
+        td->BitsPerByte = BitsPerByte;
+      break;
     }
     case 'E':
       if (td)

--- a/lib/Target/TargetData.cpp
+++ b/lib/Target/TargetData.cpp
@@ -158,10 +158,16 @@ void TargetData::init() {
   setAlignment(AGGREGATE_ALIGN, 0,  8,  0);  // struct
 }
 
-std::string TargetData::parseSpecifier(StringRef Desc, TargetData *td) {
+std::string TargetData::parseSpecifier(StringRef Desc, TargetData *td, unsigned BitsPerByte) {
 
   if (td)
     td->init();
+
+  if (BitsPerByte == 0 || BitsPerByte % 8 != 0)
+    return "invalid number of bits per byte, must be a positive multiple of 8";
+
+  if (td)
+    td->BitsPerByte = BitsPerByte;
 
   while (!Desc.empty()) {
     std::pair<StringRef, StringRef> Split = Desc.split('-');
@@ -178,15 +184,6 @@ std::string TargetData::parseSpecifier(StringRef Desc, TargetData *td) {
     assert(!Specifier.empty() && "Can't be empty here");
 
     switch (Specifier[0]) {
-    case 'B': {
-      Specifier = Specifier.substr(1);
-      int BitsPerByte = getInt(Specifier);
-      if (BitsPerByte < 0 || BitsPerByte % 8 != 0)
-        return "invalid number of bits per byte, must be a positive 8-bit multiple";
-      if (td)
-        td->BitsPerByte = BitsPerByte;
-      break;
-    }
     case 'E':
       if (td)
         td->LittleEndian = false;
@@ -199,30 +196,30 @@ std::string TargetData::parseSpecifier(StringRef Desc, TargetData *td) {
       // Pointer size.
       Split = Token.split(':');
       int PointerMemSizeBits = getInt(Split.first);
-      if (PointerMemSizeBits < 0 || PointerMemSizeBits % 8 != 0)
-        return "invalid pointer size, must be a positive 8-bit multiple";
+      if (PointerMemSizeBits < 0 || PointerMemSizeBits % BitsPerByte != 0)
+        return "invalid pointer size, must be a positive multiple of the byte width";
       if (td)
-        td->PointerMemSize = PointerMemSizeBits / 8;
+        td->PointerMemSize = PointerMemSizeBits / BitsPerByte;
 
       // Pointer ABI alignment.
       Split = Split.second.split(':');
       int PointerABIAlignBits = getInt(Split.first);
-      if (PointerABIAlignBits < 0 || PointerABIAlignBits % 8 != 0) {
+      if (PointerABIAlignBits < 0 || PointerABIAlignBits % BitsPerByte != 0) {
         return "invalid pointer ABI alignment, "
-               "must be a positive 8-bit multiple";
+               "must be a positive multiple of the byte width";
       }
       if (td)
-        td->PointerABIAlign = PointerABIAlignBits / 8;
+        td->PointerABIAlign = PointerABIAlignBits / BitsPerByte;
 
       // Pointer preferred alignment.
       Split = Split.second.split(':');
       int PointerPrefAlignBits = getInt(Split.first);
-      if (PointerPrefAlignBits < 0 || PointerPrefAlignBits % 8 != 0) {
+      if (PointerPrefAlignBits < 0 || PointerPrefAlignBits % BitsPerByte != 0) {
         return "invalid pointer preferred alignment, "
-               "must be a positive 8-bit multiple";
+               "must be a positive multiple of the byte width";
       }
       if (td) {
-        td->PointerPrefAlign = PointerPrefAlignBits / 8;
+        td->PointerPrefAlign = PointerPrefAlignBits / BitsPerByte;
         if (td->PointerPrefAlign == 0)
           td->PointerPrefAlign = td->PointerABIAlign;
       }
@@ -251,20 +248,20 @@ std::string TargetData::parseSpecifier(StringRef Desc, TargetData *td) {
 
       Split = Token.split(':');
       int ABIAlignBits = getInt(Split.first);
-      if (ABIAlignBits < 0 || ABIAlignBits % 8 != 0) {
+      if (ABIAlignBits < 0 || ABIAlignBits % BitsPerByte != 0) {
         return std::string("invalid ") + field +"-abi-alignment field, "
-               "must be a positive 8-bit multiple";
+               "must be a positive multiple of the byte width";
       }
-      unsigned ABIAlign = ABIAlignBits / 8;
+      unsigned ABIAlign = ABIAlignBits / BitsPerByte;
 
       Split = Split.second.split(':');
 
       int PrefAlignBits = getInt(Split.first);
-      if (PrefAlignBits < 0 || PrefAlignBits % 8 != 0) {
+      if (PrefAlignBits < 0 || PrefAlignBits % BitsPerByte != 0) {
         return std::string("invalid ") + field +"-preferred-alignment field, "
-               "must be a positive 8-bit multiple";
+               "must be a positive multiple of the byte width";
       }
-      unsigned PrefAlign = PrefAlignBits / 8;
+      unsigned PrefAlign = PrefAlignBits / BitsPerByte;
       if (PrefAlign == 0)
         PrefAlign = ABIAlign;
       
@@ -289,12 +286,12 @@ std::string TargetData::parseSpecifier(StringRef Desc, TargetData *td) {
       break;
     case 'S': { // Stack natural alignment.
       int StackNaturalAlignBits = getInt(Specifier.substr(1));
-      if (StackNaturalAlignBits < 0 || StackNaturalAlignBits % 8 != 0) {
+      if (StackNaturalAlignBits < 0 || StackNaturalAlignBits % BitsPerByte != 0) {
         return "invalid natural stack alignment (S-field), "
-               "must be a positive 8-bit multiple";
+               "must be a positive multiple of the byte width";
       }
       if (td)
-        td->StackNaturalAlign = StackNaturalAlignBits / 8;
+        td->StackNaturalAlign = StackNaturalAlignBits / BitsPerByte;
       break;
     }
     default:
@@ -453,14 +450,14 @@ std::string TargetData::getStringRepresentation() const {
   raw_string_ostream OS(Result);
 
   OS << (LittleEndian ? "e" : "E")
-     << "-p:" << PointerMemSize*8 << ':' << PointerABIAlign*8
-     << ':' << PointerPrefAlign*8
-     << "-S" << StackNaturalAlign*8;
+     << "-p:" << PointerMemSize*BitsPerByte << ':' << PointerABIAlign*BitsPerByte
+     << ':' << PointerPrefAlign*BitsPerByte
+     << "-S" << StackNaturalAlign*BitsPerByte;
 
   for (unsigned i = 0, e = Alignments.size(); i != e; ++i) {
     const TargetAlignElem &AI = Alignments[i];
     OS << '-' << (char)AI.AlignType << AI.TypeBitWidth << ':'
-       << AI.ABIAlign*8 << ':' << AI.PrefAlign*8;
+       << AI.ABIAlign*BitsPerByte << ':' << AI.PrefAlign*BitsPerByte;
   }
 
   if (!LegalIntWidths.empty()) {

--- a/lib/Transforms/Utils/CloneModule.cpp
+++ b/lib/Transforms/Utils/CloneModule.cpp
@@ -35,6 +35,7 @@ Module *llvm::CloneModule(const Module *M, ValueToValueMapTy &VMap) {
   // First off, we need to create the new module.
   Module *New = new Module(M->getModuleIdentifier(), M->getContext());
   New->setDataLayout(M->getDataLayout());
+  New->setBitsPerByte(M->getBitsPerByte());
   New->setTargetTriple(M->getTargetTriple());
   New->setModuleInlineAsm(M->getModuleInlineAsm());
    

--- a/lib/VMCore/Module.cpp
+++ b/lib/VMCore/Module.cpp
@@ -43,7 +43,7 @@ template class llvm::SymbolTableListTraits<GlobalAlias, Module>;
 //
 
 Module::Module(StringRef MID, LLVMContext& C)
-  : Context(C), Materializer(NULL), ModuleID(MID) {
+  : Context(C), Materializer(NULL), ModuleID(MID), BitsPerByte(8) {
   ValSymTab = new ValueSymbolTable();
   NamedMDSymTab = new StringMap<NamedMDNode *>();
   Context.addModule(this);

--- a/test/CodeGen/DCPU16/2012-04-09-i8-zeroext.ll
+++ b/test/CodeGen/DCPU16/2012-04-09-i8-zeroext.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | not grep {UNREACHABLE|ERROR}
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @hailstone() nounwind {

--- a/test/CodeGen/DCPU16/2012-04-09-locals.ll
+++ b/test/CodeGen/DCPU16/2012-04-09-locals.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
 ; RUN: llc < %s -O0 -march=dcpu16 | FileCheck %s -check-prefix=CHECK-O0
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @f(i16 %x) nounwind {

--- a/test/CodeGen/DCPU16/2012-04-09-zero-index.ll
+++ b/test/CodeGen/DCPU16/2012-04-09-zero-index.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @first(i16* %a) nounwind {

--- a/test/CodeGen/DCPU16/2012-04-10-bic.ll
+++ b/test/CodeGen/DCPU16/2012-04-10-bic.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
 ; RUN: llc < %s -O0 -march=dcpu16 | FileCheck %s -check-prefix=CHECK-O0
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @bic(i16 %a, i16 %b) nounwind readnone {

--- a/test/CodeGen/DCPU16/2012-04-10-swpb.ll
+++ b/test/CodeGen/DCPU16/2012-04-10-swpb.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @swpb(i16 %x) nounwind readnone {

--- a/test/CodeGen/DCPU16/2012-04-14-shift.ll
+++ b/test/CodeGen/DCPU16/2012-04-14-shift.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @shift_ri(i16 %a) nounwind readnone {

--- a/test/CodeGen/DCPU16/2012-04-16-illegal_increment.ll
+++ b/test/CodeGen/DCPU16/2012-04-16-illegal_increment.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define void @mul_by_17(i16* nocapture %as, i16 %size_a) nounwind {

--- a/test/CodeGen/DCPU16/AddrMode-bis-rx.ll
+++ b/test/CodeGen/DCPU16/AddrMode-bis-rx.ll
@@ -1,6 +1,6 @@
 ; XFAIL: *
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @am1(i16 %x, i16* %a) nounwind {

--- a/test/CodeGen/DCPU16/AddrMode-bis-xr.ll
+++ b/test/CodeGen/DCPU16/AddrMode-bis-xr.ll
@@ -1,6 +1,6 @@
 ; XFAIL: *
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define void @am1(i16* %a, i16 %x) nounwind {

--- a/test/CodeGen/DCPU16/AddrMode-mov-rx.ll
+++ b/test/CodeGen/DCPU16/AddrMode-mov-rx.ll
@@ -1,6 +1,6 @@
 ; XFAIL: *
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @am1(i16* %a) nounwind {

--- a/test/CodeGen/DCPU16/AddrMode-mov-xr.ll
+++ b/test/CodeGen/DCPU16/AddrMode-mov-xr.ll
@@ -1,6 +1,6 @@
 ; XFAIL: *
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define void @am1(i16* %a, i16 %b) nounwind {

--- a/test/CodeGen/DCPU16/Inst16mi.ll
+++ b/test/CodeGen/DCPU16/Inst16mi.ll
@@ -1,6 +1,6 @@
 ; RUN: llc -march=dcpu16 < %s | FileCheck %s
 
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 @foo = common global i16 0, align 2
 

--- a/test/CodeGen/DCPU16/Inst16mm.ll
+++ b/test/CodeGen/DCPU16/Inst16mm.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=dcpu16 -combiner-alias-analysis < %s | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 @foo = common global i16 0, align 2
 @bar = common global i16 0, align 2

--- a/test/CodeGen/DCPU16/Inst16mr.ll
+++ b/test/CodeGen/DCPU16/Inst16mr.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=dcpu16 < %s | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 @foo = common global i16 0, align 2
 

--- a/test/CodeGen/DCPU16/Inst16ri.ll
+++ b/test/CodeGen/DCPU16/Inst16ri.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=dcpu16 < %s | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @mov() nounwind {

--- a/test/CodeGen/DCPU16/Inst16rm.ll
+++ b/test/CodeGen/DCPU16/Inst16rm.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=dcpu16 < %s | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 @foo = common global i16 0, align 2
 

--- a/test/CodeGen/DCPU16/Inst16rr.ll
+++ b/test/CodeGen/DCPU16/Inst16rr.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=dcpu16 < %s | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @mov(i16 %a, i16 %b) nounwind {

--- a/test/CodeGen/DCPU16/add.ll
+++ b/test/CodeGen/DCPU16/add.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @sum2(i16 %a, i16 %b) nounwind {

--- a/test/CodeGen/DCPU16/and.ll
+++ b/test/CodeGen/DCPU16/and.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @f1(i16 %x, i16 %y) nounwind {

--- a/test/CodeGen/DCPU16/brcc.ll
+++ b/test/CodeGen/DCPU16/brcc.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:16:16-i8:8:8-i16:16:16-i32:16:32-i64:64:64-n8:16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @simplebranch_le(i16 %x, i16 %y, i16 %z) nounwind readnone {

--- a/test/CodeGen/DCPU16/div.ll
+++ b/test/CodeGen/DCPU16/div.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:16:16-i8:8:8-i16:16:16-i32:16:32-i64:64:64-n8:16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @div(i16 %a, i16 %b, i16* nocapture %c) nounwind readonly {

--- a/test/CodeGen/DCPU16/mod.ll
+++ b/test/CodeGen/DCPU16/mod.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:16:16-i8:8:8-i16:16:16-i32:16:32-i64:64:64-n8:16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @mod(i16 %a, i16 %b, i16* nocapture %c) nounwind readonly {

--- a/test/CodeGen/DCPU16/pointer.ll
+++ b/test/CodeGen/DCPU16/pointer.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define void @simpleInc() nounwind {

--- a/test/CodeGen/DCPU16/setcc.ll
+++ b/test/CodeGen/DCPU16/setcc.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=dcpu16 < %s | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 define i16 @sccweqand(i16 %a, i16 %b) nounwind {

--- a/test/CodeGen/DCPU16/string.ll
+++ b/test/CodeGen/DCPU16/string.ll
@@ -1,0 +1,9 @@
+; RUN: llc < %s -march=dcpu16 | FileCheck %s
+target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16-B16"
+target triple = "dcpu16"
+
+@bar = global [2 x i16] [i16 65, i16 0], align 1
+; CHECK: :bar
+; CHECK: .short 65
+; CHECK: .short 0
+; CHECK-NOT: .zero

--- a/test/CodeGen/DCPU16/string.ll
+++ b/test/CodeGen/DCPU16/string.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=dcpu16 | FileCheck %s
-target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-s0:8:8-n16-B16"
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
 target triple = "dcpu16"
 
 @bar = global [2 x i16] [i16 65, i16 0], align 1


### PR DESCRIPTION
- Change TargetData's 'WordAddressing' to 'BitsPerByte'
- add it to more computations
- make sure the code generation of strings doesn't produce huge .zero sections

Fixes #132, but not really the underlying cause (16bit bytes are still not handled correctly/cleanly).
