### PR TITLE
Rename all registers form R__ to __

### DIFF
--- a/lib/Target/DCPU16/DCPU16CallingConv.td
+++ b/lib/Target/DCPU16/DCPU16CallingConv.td
@@ -16,8 +16,8 @@ def RetCC_DCPU16 : CallingConv<[
   // Promote i8 return values to i16.
   CCIfType<[i8], CCPromoteToType<i16>>,
 
-  // i16 are returned in registers RA, RB, RC
-  CCIfType<[i16], CCAssignToReg<[RA, RB, RC]>>
+  // i16 are returned in registers A, B, C
+  CCIfType<[i16], CCAssignToReg<[A, B, C]>>
 ]>;
 
 //===----------------------------------------------------------------------===//
@@ -29,11 +29,11 @@ def CC_DCPU16 : CallingConv<[
 
   // The first 3 integer arguments of non-varargs functions are passed in
   // integer registers.
-  CCIfNotVarArg<CCIfType<[i16], CCAssignToReg<[RA, RB, RC]>>>,
+  CCIfNotVarArg<CCIfType<[i16], CCAssignToReg<[A, B, C]>>>,
 
   // Integer values get stored in stack slots that are 1 (16 bit) byte in
   // size and 1-byte aligned.
   CCIfType<[i16], CCAssignToStack<1, 1>>
 ]>;
 
-def CSR_DCPU16 : CalleeSavedRegs<(add RX, RY, RZ, RI, RJ)>;
+def CSR_DCPU16 : CalleeSavedRegs<(add X, Y, Z, I, J)>;

--- a/lib/Target/DCPU16/DCPU16FrameLowering.cpp
+++ b/lib/Target/DCPU16/DCPU16FrameLowering.cpp
@@ -62,18 +62,18 @@ void DCPU16FrameLowering::emitPrologue(MachineFunction &MF) const {
     // Update the frame offset adjustment.
     MFI->setOffsetAdjustment(-NumBytes);
 
-    // Save RJ into the appropriate stack slot...
+    // Save J into the appropriate stack slot...
     BuildMI(MBB, MBBI, DL, TII.get(DCPU16::PUSH16r))
-      .addReg(DCPU16::RJ, RegState::Kill);
+      .addReg(DCPU16::J, RegState::Kill);
 
-    // Update RJ with the new base value...
-    BuildMI(MBB, MBBI, DL, TII.get(DCPU16::MOV16rr), DCPU16::RJ)
-      .addReg(DCPU16::RSP);
+    // Update J with the new base value...
+    BuildMI(MBB, MBBI, DL, TII.get(DCPU16::MOV16rr), DCPU16::J)
+      .addReg(DCPU16::SP);
 
     // Mark the FramePtr as live-in in every block except the entry.
     for (MachineFunction::iterator I = llvm::next(MF.begin()), E = MF.end();
          I != E; ++I)
-      I->addLiveIn(DCPU16::RJ);
+      I->addLiveIn(DCPU16::J);
 
   } else
     NumBytes = StackSize - DCPU16FI->getCalleeSavedFrameSize();
@@ -85,18 +85,18 @@ void DCPU16FrameLowering::emitPrologue(MachineFunction &MF) const {
   if (MBBI != MBB.end())
     DL = MBBI->getDebugLoc();
 
-  if (NumBytes) { // adjust stack pointer: RSP -= numbytes
-    // If there is an SUB16ri of RSP immediately before this instruction, merge
+  if (NumBytes) { // adjust stack pointer: SP -= numbytes
+    // If there is an SUB16ri of SP immediately before this instruction, merge
     // the two.
     //NumBytes -= mergeSPUpdates(MBB, MBBI, true);
-    // If there is an ADD16ri or SUB16ri of RSP immediately after this
+    // If there is an ADD16ri or SUB16ri of SP immediately after this
     // instruction, merge the two instructions.
     // mergeSPUpdatesDown(MBB, MBBI, &NumBytes);
 
     if (NumBytes) {
       MachineInstr *MI =
-        BuildMI(MBB, MBBI, DL, TII.get(DCPU16::SUB16ri), DCPU16::RSP)
-        .addReg(DCPU16::RSP).addImm(NumBytes);
+        BuildMI(MBB, MBBI, DL, TII.get(DCPU16::SUB16ri), DCPU16::SP)
+        .addReg(DCPU16::SP).addImm(NumBytes);
       // The SRW implicit def is dead.
       MI->getOperand(3).setIsDead();
     }
@@ -131,8 +131,8 @@ void DCPU16FrameLowering::emitEpilogue(MachineFunction &MF,
     uint64_t FrameSize = StackSize - 2;
     NumBytes = FrameSize - CSSize;
 
-    // pop RJ.
-    BuildMI(MBB, MBBI, DL, TII.get(DCPU16::POP16r), DCPU16::RJ);
+    // pop J.
+    BuildMI(MBB, MBBI, DL, TII.get(DCPU16::POP16r), DCPU16::J);
   } else
     NumBytes = StackSize - CSSize;
 
@@ -147,19 +147,19 @@ void DCPU16FrameLowering::emitEpilogue(MachineFunction &MF,
 
   DL = MBBI->getDebugLoc();
 
-  // If there is an ADD16ri or SUB16ri of RSP immediately before this
+  // If there is an ADD16ri or SUB16ri of SP immediately before this
   // instruction, merge the two instructions.
   //if (NumBytes || MFI->hasVarSizedObjects())
   //  mergeSPUpdatesUp(MBB, MBBI, StackPtr, &NumBytes);
 
   if (MFI->hasVarSizedObjects()) {
     BuildMI(MBB, MBBI, DL,
-            TII.get(DCPU16::MOV16rr), DCPU16::RSP).addReg(DCPU16::RJ);
+            TII.get(DCPU16::MOV16rr), DCPU16::SP).addReg(DCPU16::J);
     if (CSSize) {
       MachineInstr *MI =
         BuildMI(MBB, MBBI, DL,
-                TII.get(DCPU16::SUB16ri), DCPU16::RSP)
-        .addReg(DCPU16::RSP).addImm(CSSize);
+                TII.get(DCPU16::SUB16ri), DCPU16::SP)
+        .addReg(DCPU16::SP).addImm(CSSize);
       // The SRW implicit def is dead.
       MI->getOperand(3).setIsDead();
     }
@@ -167,8 +167,8 @@ void DCPU16FrameLowering::emitEpilogue(MachineFunction &MF,
     // adjust stack pointer back: SP += numbytes
     if (NumBytes) {
       MachineInstr *MI =
-        BuildMI(MBB, MBBI, DL, TII.get(DCPU16::ADD16ri), DCPU16::RSP)
-        .addReg(DCPU16::RSP).addImm(NumBytes);
+        BuildMI(MBB, MBBI, DL, TII.get(DCPU16::ADD16ri), DCPU16::SP)
+        .addReg(DCPU16::SP).addImm(NumBytes);
       // The SRW implicit def is dead.
       MI->getOperand(3).setIsDead();
     }

--- a/lib/Target/DCPU16/DCPU16ISelLowering.cpp
+++ b/lib/Target/DCPU16/DCPU16ISelLowering.cpp
@@ -56,7 +56,7 @@ DCPU16TargetLowering::DCPU16TargetLowering(DCPU16TargetMachine &tm) :
   setIntDivIsCheap(true);
   setPow2DivIsCheap(true);
 
-  setStackPointerRegisterToSaveRestore(DCPU16::RSP);
+  setStackPointerRegisterToSaveRestore(DCPU16::SP);
   setBooleanContents(ZeroOrOneBooleanContent);
   setBooleanVectorContents(ZeroOrOneBooleanContent); // FIXME: Is this correct?
 
@@ -183,11 +183,11 @@ DCPU16TargetLowering::LowerFormalArguments(SDValue Chain,
     if (Ins.size() != 1 || Ins[0].VT != MVT::i16)
       report_fatal_error("Interrupt handlers take exactly one integer or unsigned argument");
 
-    // Copy to virtual register from RA
+    // Copy to virtual register from A
     MachineRegisterInfo &RegInfo = DAG.getMachineFunction().getRegInfo();
     unsigned VReg =
       RegInfo.createVirtualRegister(DCPU16::GR16RegisterClass);
-    RegInfo.addLiveIn(DCPU16::RA, VReg);
+    RegInfo.addLiveIn(DCPU16::A, VReg);
     SDValue ArgValue = DAG.getCopyFromReg(Chain, dl, VReg, MVT::i16);
     InVals.push_back(ArgValue);
 
@@ -419,7 +419,7 @@ DCPU16TargetLowering::LowerCCCCallTo(SDValue Chain, SDValue Callee,
       assert(VA.isMemLoc());
 
       if (StackPtr.getNode() == 0)
-        StackPtr = DAG.getCopyFromReg(Chain, dl, DCPU16::RSP, getPointerTy());
+        StackPtr = DAG.getCopyFromReg(Chain, dl, DCPU16::SP, getPointerTy());
 
       SDValue PtrOff = DAG.getNode(ISD::ADD, dl, getPointerTy(),
                                    StackPtr,
@@ -728,7 +728,7 @@ SDValue DCPU16TargetLowering::LowerFRAMEADDR(SDValue Op,
   DebugLoc dl = Op.getDebugLoc();  // FIXME probably not meaningful
   unsigned Depth = cast<ConstantSDNode>(Op.getOperand(0))->getZExtValue();
   SDValue FrameAddr = DAG.getCopyFromReg(DAG.getEntryNode(), dl,
-                                         DCPU16::RJ, VT);
+                                         DCPU16::J, VT);
   while (Depth--)
     FrameAddr = DAG.getLoad(VT, dl, DAG.getEntryNode(), FrameAddr,
                             MachinePointerInfo(),

--- a/lib/Target/DCPU16/DCPU16InstrInfo.td
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.td
@@ -103,8 +103,8 @@ def and_su : PatFrag<(ops node:$lhs, node:$rhs), (and node:$lhs, node:$rhs), [{
 // a stack adjustment and the codegen must know that they may modify the stack
 // pointer before prolog-epilog rewriting occurs.
 // Pessimistically assume ADJCALLSTACKDOWN / ADJCALLSTACKUP will become
-// sub / add which can clobber REX.
-let Defs = [RSP, REX], Uses = [RSP] in {
+// sub / add which can clobber EX.
+let Defs = [SP, EX], Uses = [SP] in {
 def ADJCALLSTACKDOWN : Pseudo<(outs), (ins i16imm:$amt),
                               "#ADJCALLSTACKDOWN",
                               [(DCPU16callseq_start timm:$amt)]>;
@@ -227,12 +227,12 @@ def BR_CCii : CJForm<0, 0,
 //  Call Instructions...
 //
 let isCall = 1 in
-  // All calls clobber the non-callee saved registers. RSP is marked as
+  // All calls clobber the non-callee saved registers. SP is marked as
   // a use to prevent stack-pointer assignments that appear immediately
   // before calls from potentially appearing dead. Uses for argument
   // registers are added manually.
-  let Defs = [REX],
-      Uses = [RSP] in {
+  let Defs = [EX],
+      Uses = [SP] in {
     def CALLi     : II16i<0x0,
                           (outs), (ins i16imm:$dst, variable_ops),
                           "JSR\t$dst", [(DCPU16call imm:$dst)]>;
@@ -248,7 +248,7 @@ let isCall = 1 in
 //===----------------------------------------------------------------------===//
 //  Miscellaneous Instructions...
 //
-let Defs = [RSP], Uses = [RSP], neverHasSideEffects=1 in {
+let Defs = [SP], Uses = [SP], neverHasSideEffects=1 in {
 let mayLoad = 1 in
 def POP16r   : IForm16<0x0, DstReg, SrcPostInc, Size2Bytes,
                        (outs GR16:$reg), (ins), "SET\t{$reg, POP}", []>;
@@ -315,7 +315,7 @@ multiclass BASIC_RR_IS_COM<bits<4> OpVal, string OpcStr, SDNode OpNode> {
                     (outs GR16:$dst), (ins GR16:$src, GR16:$src2),
                     OpcStr#"\t{$dst, $src2}",
                     [(set GR16:$dst, (OpNode GR16:$src, GR16:$src2)),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   }
 }
 
@@ -325,7 +325,7 @@ multiclass BASIC_RR_NON_COM<bits<4> OpVal, string OpcStr, SDNode OpNode> {
                     (outs GR16:$dst), (ins GR16:$src, GR16:$src2),
                     OpcStr#"\t{$dst, $src2}",
                     [(set GR16:$dst, (OpNode GR16:$src, GR16:$src2)),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   }
 }
 
@@ -335,30 +335,30 @@ multiclass BASIC_NORMAL<bits<4> OpVal, string OpcStr, SDNode OpNode> {
                     (outs GR16:$dst), (ins GR16:$src, memsrc:$src2),
                     OpcStr#"\t{$dst, $src2}",
                     [(set GR16:$dst, (OpNode GR16:$src, (load addr:$src2))),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   def ri: I16ri<OpVal,
                     (outs GR16:$dst), (ins GR16:$src, i16imm:$src2),
                     OpcStr#"\t{$dst, $src2}",
                     [(set GR16:$dst, (OpNode GR16:$src, imm:$src2)),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   }
   let Constraints = "" in {
   def mr: I16mr<OpVal,
                     (outs), (ins memdst:$dst, GR16:$src),
                     OpcStr#"\t{$dst, $src}",
                     [(store (OpNode (load addr:$dst), GR16:$src), addr:$dst),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   def mi: I16mi<OpVal,
                     (outs), (ins memdst:$dst, i16imm:$src),
                     OpcStr#"\t{$dst, $src}",
                     [(store (OpNode (load addr:$dst), (i16 imm:$src)), addr:$dst),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   def mm: I16mm<OpVal,
                     (outs), (ins memdst:$dst, memsrc:$src),
                     OpcStr#"\t{$dst, $src}",
                     [(store (OpNode (load addr:$dst),
                                   (i16 (load addr:$src))), addr:$dst),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   }
   
   // FIXME! Wrong zero extend
@@ -367,14 +367,14 @@ multiclass BASIC_NORMAL<bits<4> OpVal, string OpcStr, SDNode OpNode> {
                     (outs GR16:$dst), (ins GR16:$src, memsrc:$src2),
 					OpcStr#"\t{$dst, $src}",
                     [(set GR16:$dst, (OpNode GR16:$src, (zextloadi8 addr:$src2))),
-                     (implicit REX)]>;
+                     (implicit EX)]>;
   }  
 }
 
 //===----------------------------------------------------------------------===//
 // Arithmetic Instructions
 
-let Defs = [REX] in {
+let Defs = [EX] in {
   defm ADD16   : BASIC_RR_IS_COM <0x0, "ADD", add>,  BASIC_NORMAL<0x0, "ADD", add>;
   defm AND16   : BASIC_RR_IS_COM <0x0, "AND", and>,  BASIC_NORMAL<0x0, "AND", and>;
   defm OR16    : BASIC_RR_IS_COM <0x0, "BOR", or>,   BASIC_NORMAL<0x0, "BOR", or>;
@@ -389,12 +389,12 @@ let Defs = [REX] in {
   defm UREM16  : BASIC_RR_NON_COM<0x0, "MOD", urem>, BASIC_NORMAL<0x0, "MOD", urem>;
   defm SREM16  : BASIC_RR_NON_COM<0x0, "MDI", srem>, BASIC_NORMAL<0x0, "MDI", srem>;
 
-  let Uses = [REX] in {
+  let Uses = [EX] in {
     defm ADC16   : BASIC_RR_IS_COM <0x0, "ADX", adde>, BASIC_NORMAL<0x0, "ADX", adde>;
     defm SBC16   : BASIC_RR_NON_COM<0x0, "SBX", sube>, BASIC_NORMAL<0x0, "SBX", sube>;
   }
 
-} // Defs = [REX]
+} // Defs = [EX]
 
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/DCPU16/DCPU16RegisterInfo.td
+++ b/lib/Target/DCPU16/DCPU16RegisterInfo.td
@@ -20,28 +20,28 @@ class DCPU16Reg<bits<5> num, string n> : Register<n> {
 //  Registers
 //===----------------------------------------------------------------------===//
 
-def RA  : DCPU16Reg<0x0,  "A">;
-def RB  : DCPU16Reg<0x1,  "B">;
-def RC  : DCPU16Reg<0x2,  "C">;
-def RX  : DCPU16Reg<0x3,  "X">;
-def RY  : DCPU16Reg<0x4,  "Y">;
-def RZ  : DCPU16Reg<0x5,  "Z">;
-def RI  : DCPU16Reg<0x6,  "I">;
-def RJ  : DCPU16Reg<0x7,  "J">; // FP if needed
+def A  : DCPU16Reg<0x0,  "A">;
+def B  : DCPU16Reg<0x1,  "B">;
+def C  : DCPU16Reg<0x2,  "C">;
+def X  : DCPU16Reg<0x3,  "X">;
+def Y  : DCPU16Reg<0x4,  "Y">;
+def Z  : DCPU16Reg<0x5,  "Z">;
+def I  : DCPU16Reg<0x6,  "I">;
+def J  : DCPU16Reg<0x7,  "J">; // FP if needed
 
-def RSP  : DCPU16Reg<0x1b,  "SP">;
-def REX  : DCPU16Reg<0x1d,  "EX">;
+def SP  : DCPU16Reg<0x1b,  "SP">;
+def EX  : DCPU16Reg<0x1d,  "EX">;
 
 // Volatile registers
 def GR16 : RegisterClass<"DCPU16", [i16], 16,
-  (add RA,RB,RC,RX,RY,RZ,RI,RJ)>;
+  (add A,B,C,X,Y,Z,I,J)>;
 
 // Stack pointer register
 def SPR16 : RegisterClass<"DCPU16", [i16], 16,
-  (add RSP)>;
+  (add SP)>;
   
 // Overflow register
 def EXR16 : RegisterClass<"DCPU16", [i16], 16,
-  (add REX)> {
+  (add EX)> {
    let isAllocatable = 0;
 }

--- a/lib/Target/DCPU16/MCTargetDesc/DCPU16MCTargetDesc.cpp
+++ b/lib/Target/DCPU16/MCTargetDesc/DCPU16MCTargetDesc.cpp
@@ -39,7 +39,7 @@ static MCInstrInfo *createDCPU16MCInstrInfo() {
 
 static MCRegisterInfo *createDCPU16MCRegisterInfo(StringRef TT) {
   MCRegisterInfo *X = new MCRegisterInfo();
-  InitDCPU16MCRegisterInfo(X, DCPU16::RA);
+  InitDCPU16MCRegisterInfo(X, DCPU16::A);
   return X;
 }
 

--- a/test/CodeGen/DCPU16/inline_asm.ll
+++ b/test/CodeGen/DCPU16/inline_asm.ll
@@ -1,0 +1,24 @@
+; RUN: llc < %s -march=dcpu16 | FileCheck %s
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
+target triple = "dcpu16"
+
+define void @clear_keyboard_buffer(i16 %device_id) nounwind {
+entry:
+  tail call void asm sideeffect "SET A, 0", "~{A}"() nounwind
+  tail call void asm sideeffect "HWI $0", "r"(i16 %device_id) nounwind
+  ret void
+}
+; CHECK: :clear_keyboard_buffer
+; CHECK: SET B, A
+; CHECK: SET A, 0
+; CHECK: HWI B
+
+define void @register_tango(i16 %in, i16* %out) nounwind {
+entry:
+  tail call void asm sideeffect "SET $0, $1", "=*m,{B}"(i16* %out, i16 %in) nounwind
+  ret void
+}
+; CHECK: :register_tango
+; CHECK: SET C, B
+; CHECK: SET B, A
+; CHECK: SET [C], B


### PR DESCRIPTION
This is necessary, so inline asm constraints work. Before this change,
LLVM could not translate from a constraint on register "A" (used in clang
and when writing inline asm) to the register "RA" (defined in the DCPU16
backend) and just silently(!) discarded the constraint.

Man, it was really frustrating trying to find out why my constraints weren't respected. Inline asm is a bit of a black art as it is and I lost a lot of time thinking I made mistakes, while all the constraints were just ignored...
