### PR TITLE
Use DCPU16 PICK n syntax instead of [n+SP] syntax

### DIFF
--- a/lib/Target/DCPU16/DCPU16AsmPrinter.cpp
+++ b/lib/Target/DCPU16/DCPU16AsmPrinter.cpp
@@ -113,17 +113,28 @@ void DCPU16AsmPrinter::printSrcMemOperand(const MachineInstr *MI, int OpNum,
   const MachineOperand &Base = MI->getOperand(OpNum);
   const MachineOperand &Disp = MI->getOperand(OpNum+1);
 
+  // Special case for PICK n syntax
+  if (Base.getReg() == DCPU16::SP) {
+    if (Disp.isImm()) {
+      O << "PICK 0x";
+      O.write_hex(Disp.getImm() & 0xFFFF);
+    } else {
+      llvm_unreachable("Unsupported src mem expression in inline asm");
+    }
+    return;
+  }
+
   if (Base.getReg())
     O << '[';
 
-  if(Disp.isImm()) {
-	  if (Disp.getImm() != 0) {
-        O << "0x";
-        O.write_hex((Disp.getImm()) & 0xFFFF);
-        O << "+";
-	  }
+  if (Disp.isImm()) {
+    if (Disp.getImm() != 0) {
+      O << "0x";
+      O.write_hex((Disp.getImm()) & 0xFFFF);
+      O << "+";
+    }
   } else {
-	  llvm_unreachable("Unsupported src mem operand in inline asm");
+    llvm_unreachable("Unsupported src mem operand in inline asm");
   }
 
   // Print register base field

--- a/lib/Target/DCPU16/InstPrinter/DCPU16InstPrinter.cpp
+++ b/lib/Target/DCPU16/InstPrinter/DCPU16InstPrinter.cpp
@@ -64,6 +64,20 @@ void DCPU16InstPrinter::printSrcMemOperand(const MCInst *MI, unsigned OpNo,
   const MCOperand &Base = MI->getOperand(OpNo);
   const MCOperand &Disp = MI->getOperand(OpNo+1);
 
+  // Special case for PICK n syntax
+  if (Base.getReg() == DCPU16::SP) {
+    if (Disp.isImm()) {
+      O << "PICK 0x";
+      O.write_hex(Disp.getImm() & 0xFFFF);
+    } else {
+      assert(Disp.isExpr() &&
+             "Expected immediate or expression in displacement field");
+      O << "PICK ";
+      O << *Disp.getExpr();
+    }
+    return;
+  }
+
   O << '[';
 
   if (Disp.isExpr()) {

--- a/test/CodeGen/DCPU16/2012-04-09-zero-index.ll
+++ b/test/CodeGen/DCPU16/2012-04-09-zero-index.ll
@@ -13,5 +13,5 @@ entry:
 }
 
 ; CHECK: :first
-; CHECK: SET [SP], {{.}}
+; CHECK: SET PICK 0x0, {{.}}
 ; CHECK: SET {{.}}, [{{.}}]

--- a/test/CodeGen/DCPU16/2012-04-24-memsrc-asm.ll
+++ b/test/CodeGen/DCPU16/2012-04-24-memsrc-asm.ll
@@ -13,4 +13,4 @@ entry:
 !0 = metadata !{i32 58}
 
 ; CHECK: :func
-; CHECK: SET [SP], SP
+; CHECK: SET PICK 0x0, SP

--- a/test/CodeGen/DCPU16/add.ll
+++ b/test/CodeGen/DCPU16/add.ll
@@ -14,4 +14,4 @@ entry:
   ret i16 %add
 }
 ; CHECK: :sum2
-; CHECK: {{ADD ., \[0x[0-9a-f]\+SP\]}}
+; CHECK: {{ADD ., PICK 0x[0-9a-f]}}

--- a/test/CodeGen/DCPU16/adx.ll
+++ b/test/CodeGen/DCPU16/adx.ll
@@ -19,6 +19,6 @@ entry:
   ret i16 0
 }
 
-; CHECK:        ADD     A, [0x{{.}}+SP]
-; CHECK:        ADX     B, [0x{{.}}+SP]
+; CHECK:        ADD     A, PICK 0x{{.}}
+; CHECK:        ADX     B, PICK 0x{{.}}
 

--- a/test/CodeGen/DCPU16/and.ll
+++ b/test/CodeGen/DCPU16/and.ll
@@ -14,9 +14,9 @@ entry:
   ret i16 %and
 }
 ; CHECK: :f1
-; CHECK: SET [0x1+SP], A
-; CHECK: SET [SP], B
-; CHECK: AND B, [0x1+SP]
+; CHECK: SET PICK 0x1, A
+; CHECK: SET PICK 0x0, B
+; CHECK: AND B, PICK 0x1
 ; CHECK: SET A, B
 ; CHECK: ADD SP, 0x2
 

--- a/test/CodeGen/DCPU16/pointer.ll
+++ b/test/CodeGen/DCPU16/pointer.ll
@@ -13,5 +13,5 @@ entry:
 }
 
 ; CHECK: :simpleInc
-; CHECK: SET [SP], 0x8000
-; CHECK: SET [SP], 0x8001
+; CHECK: SET PICK 0x0, 0x8000
+; CHECK: SET PICK 0x0, 0x8001


### PR DESCRIPTION
as discussed in issue #159.  This also fixes inline assembly; I hadn't realized there was a separate inline asm instruction generator.  All tests pass.
