### PR TITLE
Remove duplicate branches.

### DIFF
--- a/lib/Target/DCPU16/CMakeLists.txt
+++ b/lib/Target/DCPU16/CMakeLists.txt
@@ -21,6 +21,7 @@ add_llvm_target(DCPU16CodeGen
   DCPU16AsmPrinter.cpp
   DCPU16MCInstLower.cpp
   DCPU16Peephole.cpp
+  DCPU16DuplicateBranch.cpp
   )
 
 add_subdirectory(InstPrinter)

--- a/lib/Target/DCPU16/DCPU16.h
+++ b/lib/Target/DCPU16/DCPU16.h
@@ -48,6 +48,9 @@ namespace llvm {
 
   FunctionPass *createDCPU16ISelDag(DCPU16TargetMachine &TM, CodeGenOpt::Level OptLevel);
   FunctionPass *createDCPU16Peephole();
+  FunctionPass *createDCPU16DuplicateBranch();
+
+  bool isBR_CC(unsigned Opcode);
 
 } // end namespace llvm;
 

--- a/lib/Target/DCPU16/DCPU16DuplicateBranch.cpp
+++ b/lib/Target/DCPU16/DCPU16DuplicateBranch.cpp
@@ -104,27 +104,29 @@ bool DCPU16DuplicateBranch::runOnMachineFunction(MachineFunction &MF) {
     MachineBasicBlock* MBB = MBBb;
 
     // Traverse the basic block.
-    for (MachineBasicBlock::iterator MII = MBB->begin(), MIIe = MBB->end();
-         MII != MIIe; ++MII) {
-
+    MachineBasicBlock::iterator MII = MBB->begin(), MIIe = MBB->end();
+    while (MII != MIIe) {
       MachineInstr *MI = MII;
 
       if (isBR_CC(MI->getOpcode())) {
         if (prevBRCC != NULL
             && isSameBR_CC(prevBRCC, MI)) {
 
-          MII->eraseFromParent();
-          // Restart loop
-          MII = MBB->begin();
-          prevBRCC = NULL;
-
+          MachineBasicBlock::iterator oldMII = MII;
+          ++MII;
+          oldMII->eraseFromParent();
           Changed = true;
+
+          // Step over the additional ++MII;
+          continue;
         } else {
           prevBRCC = MI;
         }
       } else {
         prevBRCC = NULL;
       }
+
+      ++MII;
     }
   }
 

--- a/lib/Target/DCPU16/DCPU16DuplicateBranch.cpp
+++ b/lib/Target/DCPU16/DCPU16DuplicateBranch.cpp
@@ -1,0 +1,136 @@
+//===-- DCPU16DuplicateBranch.cpp - DCPU16 Duplicate Branch Optimization --===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass optimizes "duplicate" branches. This can happen if we have a
+// sequence as follows (pseudocode):
+//
+// if (a == b) {
+//   goto branch1;
+// } else if (a >= b) {
+//   goto branch2;
+// }
+//
+// Due to the slightly strange branches of the DCPU16, this will be assembled
+// to:
+//
+// ; a == b
+// IFE A, B
+// SET PC, branch1
+// ; a >= b
+// IFE A, B
+// SET PC, branch2
+// IFG A, B
+// SET PC, branch2
+//
+// As you can see, the second `IFE` is superfluous and can be deleted.
+//
+// CAUTION: Only run this pass just before machine code generation (or any
+// other time when it is guaranteed that the relative position of basic blocks
+// doesn't change anymore)!
+//
+//===----------------------------------------------------------------------===//
+
+#include "DCPU16.h"
+#include "DCPU16TargetMachine.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+
+using namespace llvm;
+
+namespace {
+  class DCPU16DuplicateBranch : public MachineFunctionPass {
+
+  public:
+    static char ID;
+    DCPU16DuplicateBranch() : MachineFunctionPass(ID) { }
+
+    bool runOnMachineFunction(MachineFunction &MF);
+
+    const char *getPassName() const {
+      return "DCPU16 duplicate branch optimization";
+    }
+  };
+}
+
+char DCPU16DuplicateBranch::ID = 0; 
+
+static bool isSameMachineOperand(MachineOperand &MO1, MachineOperand &MO2) {
+  if (MO1.isImm()) {
+    if (!MO2.isImm() || MO1.getImm() != MO2.getImm())
+      return false;
+  } else if (MO1.isReg()) {
+    if (!MO2.isReg() || MO1.getReg() != MO2.getReg())
+      return false;
+  } else {
+    assert(false && "Only registers and immediates supported");
+  }
+  return true;
+}
+
+static bool isSameBR_CC(MachineInstr *MI1, MachineInstr *MI2) {
+  assert(isBR_CC(MI1->getOpcode()) && "not a BR_CC");
+  assert(isBR_CC(MI2->getOpcode()) && "not a BR_CC");
+  if (MI1->getOpcode() != MI2->getOpcode())
+    // Different opcode (and as a result different LHS/RHS)
+    return false;
+  if (MI1->getOperand(0).getImm() != MI2->getOperand(0).getImm())
+    // Different comparison/branch code
+    return false;
+  MachineOperand &LHS1 = MI1->getOperand(1);
+  MachineOperand &RHS1 = MI1->getOperand(2);
+  MachineOperand &LHS2 = MI2->getOperand(1);
+  MachineOperand &RHS2 = MI2->getOperand(2);
+  if (!isSameMachineOperand(LHS1, LHS2) || !isSameMachineOperand(RHS1, RHS2))
+    return false;
+
+  return true;
+}
+
+bool DCPU16DuplicateBranch::runOnMachineFunction(MachineFunction &MF) {
+  bool Changed = false;
+  // Kept when iterating over basic blocks. Should be ok, as long as this
+  // pass is only used at the end (i.e. just before machine code generation).
+  MachineInstr *prevBRCC = NULL;
+
+  // Loop over all of the basic blocks.
+  for (MachineFunction::iterator MBBb = MF.begin(), MBBe = MF.end();
+       MBBb != MBBe; ++MBBb) {
+
+    MachineBasicBlock* MBB = MBBb;
+
+    // Traverse the basic block.
+    for (MachineBasicBlock::iterator MII = MBB->begin(), MIIe = MBB->end();
+         MII != MIIe; ++MII) {
+
+      MachineInstr *MI = MII;
+
+      if (isBR_CC(MI->getOpcode())) {
+        if (prevBRCC != NULL
+            && isSameBR_CC(prevBRCC, MI)) {
+
+          MII->eraseFromParent();
+          // Restart loop
+          MII = MBB->begin();
+          prevBRCC = NULL;
+
+          Changed = true;
+        } else {
+          prevBRCC = MI;
+        }
+      } else {
+        prevBRCC = NULL;
+      }
+    }
+  }
+
+  return Changed;
+}
+
+FunctionPass *llvm::createDCPU16DuplicateBranch() {
+  return new DCPU16DuplicateBranch();
+}

--- a/lib/Target/DCPU16/DCPU16InstrInfo.cpp
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.cpp
@@ -105,7 +105,7 @@ void DCPU16InstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     .addReg(SrcReg, getKillRegState(KillSrc));
 }
 
-static bool isBR_CC(unsigned Opcode) {
+bool llvm::isBR_CC(unsigned Opcode) {
   switch (Opcode) {
     default: return false;
     case DCPU16::BR_CCrr:

--- a/lib/Target/DCPU16/DCPU16TargetMachine.cpp
+++ b/lib/Target/DCPU16/DCPU16TargetMachine.cpp
@@ -51,6 +51,7 @@ public:
   }
 
   virtual bool addInstSelector();
+  virtual bool addPreEmitPass();
 };
 } // namespace
 
@@ -64,4 +65,9 @@ bool DCPU16PassConfig::addInstSelector() {
   // Peephole optimisations
   PM->add(createDCPU16Peephole());
   return false;
+}
+
+bool DCPU16PassConfig::addPreEmitPass() {
+  PM->add(createDCPU16DuplicateBranch());
+  return true;
 }

--- a/test/CodeGen/DCPU16/duplicate_branch.ll
+++ b/test/CodeGen/DCPU16/duplicate_branch.ll
@@ -1,0 +1,37 @@
+; RUN: llc < %s -march=dcpu16 | FileCheck %s
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
+target triple = "dcpu16"
+
+define void @duplicate_branch(i16 %a, i16 %b, i16 %c) nounwind {
+entry:
+  %cmp = icmp eq i16 %a, %b
+  br i1 %cmp, label %return, label %if.else
+
+if.else:                                          ; preds = %entry
+  %cmp1 = icmp slt i16 %a, %b
+  br i1 %cmp1, label %if.then2, label %if.else3
+
+if.then2:                                         ; preds = %if.else
+  %div = sdiv i16 %c, 10
+  br label %if.end4
+
+if.else3:                                         ; preds = %if.else
+  %mul = mul nsw i16 %c, 10
+  br label %if.end4
+
+if.end4:                                          ; preds = %if.then2, %if.else3
+  %c.addr.0 = phi i16 [ %div, %if.then2 ], [ %mul, %if.else3 ]
+  tail call void @foo(i16 %c.addr.0) nounwind
+  br label %return
+
+return:                                           ; preds = %entry, %if.end4
+  ret void
+}
+; CHECK: :duplicate_branch
+; CHECK: IFE A, B
+; CHECK: SET PC, .LBB0_5
+; CHECK-NOT: IFE A, B
+; CHECK: IFA A, B
+; CHECK: SET PC, .LBB0_3
+
+declare void @foo(i16)


### PR DESCRIPTION
The DCPU16 backend can generate duplicate branches when generating code
for == comparisons followed by >= or <= comparisons. See the test and
the new optimization pass for details.

This fixes the duplicate IFE instructions reported by #168.

I'm not sure if this is the correct approach or if some easier or more general method
is available. This code will have to be rewritten when we decompose the BRCC instructions
into "real" instructions (#141).
