### PR TITLE
Make the EX register more useful and implement rotation

### DIFF
--- a/lib/Target/DCPU16/DCPU16ISelLowering.cpp
+++ b/lib/Target/DCPU16/DCPU16ISelLowering.cpp
@@ -46,6 +46,7 @@ DCPU16TargetLowering::DCPU16TargetLowering(DCPU16TargetMachine &tm) :
 
   // Set up the register classes.
   addRegisterClass(MVT::i16, &DCPU16::GR16RegClass);
+  addRegisterClass(MVT::i16, &DCPU16::GEXR16RegClass);
 
   // Compute derived properties from the register classes
   computeRegisterProperties();

--- a/lib/Target/DCPU16/DCPU16ISelLowering.cpp
+++ b/lib/Target/DCPU16/DCPU16ISelLowering.cpp
@@ -66,8 +66,8 @@ DCPU16TargetLowering::DCPU16TargetLowering(DCPU16TargetMachine &tm) :
   setLoadExtAction(ISD::ZEXTLOAD, MVT::i1,  Promote);
   setLoadExtAction(ISD::SEXTLOAD, MVT::i16, Expand);
 
-  setOperationAction(ISD::ROTL,             MVT::i16,   Expand);
-  setOperationAction(ISD::ROTR,             MVT::i16,   Expand);
+  setOperationAction(ISD::ROTL,             MVT::i16,   Custom);
+  setOperationAction(ISD::ROTR,             MVT::i16,   Custom);
   setOperationAction(ISD::BSWAP,            MVT::i16,   Expand);
   setOperationAction(ISD::GlobalAddress,    MVT::i16,   Custom);
   setOperationAction(ISD::ExternalSymbol,   MVT::i16,   Custom);
@@ -117,6 +117,8 @@ SDValue DCPU16TargetLowering::LowerOperation(SDValue Op,
   case ISD::SIGN_EXTEND:      return LowerSIGN_EXTEND(Op, DAG);
   case ISD::RETURNADDR:       return LowerRETURNADDR(Op, DAG);
   case ISD::FRAMEADDR:        return LowerFRAMEADDR(Op, DAG);
+  case ISD::ROTL:             return LowerROTL(Op, DAG);
+  case ISD::ROTR:             return LowerROTR(Op, DAG);
   default:
     llvm_unreachable("unimplemented operand");
   }
@@ -735,14 +737,43 @@ SDValue DCPU16TargetLowering::LowerFRAMEADDR(SDValue Op,
   return FrameAddr;
 }
 
+SDValue DCPU16TargetLowering::LowerROTL(SDValue Op,
+                                        SelectionDAG &DAG) const {
+  EVT VT = Op.getValueType();
+  DebugLoc dl = Op.getDebugLoc();
+
+  SDValue LHS    = Op.getOperand(0);
+  SDValue RHS    = Op.getOperand(1);
+
+  SDVTList VTs = DAG.getVTList(VT);
+  SDValue Ops[] = {LHS, RHS};
+  SDValue SHLNode = DAG.getNode(ISD::SHL, dl, VTs, Ops, 2);
+
+  SDValue Ops2[] = {SHLNode, DAG.getCopyFromReg(SHLNode, dl, DCPU16::EX, VT)};
+  return DAG.getNode(ISD::OR, dl, VTs, Ops2, 2);
+}
+
+SDValue DCPU16TargetLowering::LowerROTR(SDValue Op,
+                                        SelectionDAG &DAG) const {
+  EVT VT = Op.getValueType();
+  DebugLoc dl = Op.getDebugLoc();
+
+  SDValue LHS    = Op.getOperand(0);
+  SDValue RHS    = Op.getOperand(1);
+
+  SDVTList VTs = DAG.getVTList(VT);
+  SDValue Ops[] = {LHS, RHS};
+  SDValue SRLNode = DAG.getNode(ISD::SRL, dl, VTs, Ops, 2);
+
+  SDValue Ops2[] = {SRLNode, DAG.getCopyFromReg(SRLNode, dl, DCPU16::EX, VT)};
+  return DAG.getNode(ISD::OR, dl, VTs, Ops2, 2);
+}
+
 const char *DCPU16TargetLowering::getTargetNodeName(unsigned Opcode) const {
   switch (Opcode) {
   default: return NULL;
   case DCPU16ISD::RET_FLAG:           return "DCPU16ISD::RET_FLAG";
   case DCPU16ISD::RETI_FLAG:          return "DCPU16ISD::RETI_FLAG";
-  case DCPU16ISD::RRA:                return "DCPU16ISD::RRA";
-  case DCPU16ISD::RLA:                return "DCPU16ISD::RLA";
-  case DCPU16ISD::RRC:                return "DCPU16ISD::RRC";
   case DCPU16ISD::CALL:               return "DCPU16ISD::CALL";
   case DCPU16ISD::Wrapper:            return "DCPU16ISD::Wrapper";
   case DCPU16ISD::BR_CC:              return "DCPU16ISD::BR_CC";

--- a/lib/Target/DCPU16/DCPU16ISelLowering.h
+++ b/lib/Target/DCPU16/DCPU16ISelLowering.h
@@ -30,12 +30,6 @@ namespace llvm {
       /// Same as RET_FLAG, but used for returning from ISRs.
       RETI_FLAG,
 
-      /// Y = R{R,L}A X, rotate right (left) arithmetically
-      RRA, RLA,
-
-      /// Y = RRC X, rotate right via carry
-      RRC,
-
       /// CALL - These operations represent an abstract call
       /// instruction, which includes a bunch of information.
       CALL,
@@ -81,6 +75,8 @@ namespace llvm {
     SDValue LowerSIGN_EXTEND(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerRETURNADDR(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerFRAMEADDR(SDValue Op, SelectionDAG &DAG) const;
+    SDValue LowerROTL(SDValue Op, SelectionDAG &DAG) const;
+    SDValue LowerROTR(SDValue Op, SelectionDAG &DAG) const;
     SDValue getReturnAddressFrameIndex(SelectionDAG &DAG) const;
 
     TargetLowering::ConstraintType

--- a/lib/Target/DCPU16/DCPU16InstrInfo.cpp
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.cpp
@@ -47,7 +47,7 @@ void DCPU16InstrInfo::storeRegToStackSlot(MachineBasicBlock &MBB,
                             MFI.getObjectSize(FrameIdx),
                             MFI.getObjectAlignment(FrameIdx));
 
-  if (RC == &DCPU16::GR16RegClass)
+  if (RC == &DCPU16::GR16RegClass || RC == &DCPU16::GEXR16RegClass)
     BuildMI(MBB, MI, DL, get(DCPU16::MOV16mr))
       .addFrameIndex(FrameIdx).addImm(0)
       .addReg(SrcReg, getKillRegState(isKill)).addMemOperand(MMO);
@@ -71,7 +71,7 @@ void DCPU16InstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
                             MFI.getObjectSize(FrameIdx),
                             MFI.getObjectAlignment(FrameIdx));
 
-  if (RC == &DCPU16::GR16RegClass)
+  if (RC == &DCPU16::GR16RegClass || RC == &DCPU16::GEXR16RegClass)
     BuildMI(MBB, MI, DL, get(DCPU16::MOV16rm))
       .addReg(DestReg).addFrameIndex(FrameIdx).addImm(0).addMemOperand(MMO);
   else

--- a/lib/Target/DCPU16/DCPU16InstrInfo.td
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.td
@@ -116,49 +116,49 @@ def ADJCALLSTACKUP   : Pseudo<(outs), (ins i16imm:$amt1, i16imm:$amt2),
 // $dst _can_ be $falseV
 let Constraints = "@earlyclobber $dst" in {
   // TODO: add more combinations, in particular memory access
-  def Select16rrrr : Pseudo<(outs GR16:$dst),
-                  (ins cc:$cc, GR16:$lhs, GR16:$rhs, GR16:$trueV, GR16:$falseV),
+  def Select16rrrr : Pseudo<(outs GEXR16:$dst),
+                  (ins cc:$cc, GEXR16:$lhs, GEXR16:$rhs, GEXR16:$trueV, GEXR16:$falseV),
                   "SET\t{$dst, $falseV}\n"
                   "\t$cc\t{$lhs, $rhs}\n"
                   "\tSET\t{$dst, $trueV}",
-                  [(set GR16:$dst,
-                    (DCPU16selectcc imm:$cc, GR16:$lhs, GR16:$rhs, GR16:$trueV, GR16:$falseV))]>;
-  def Select16rirr : Pseudo<(outs GR16:$dst),
-                  (ins cc:$cc, GR16:$lhs, i16imm:$rhs, GR16:$trueV, GR16:$falseV),
+                  [(set GEXR16:$dst,
+                    (DCPU16selectcc imm:$cc, GEXR16:$lhs, GEXR16:$rhs, GEXR16:$trueV, GEXR16:$falseV))]>;
+  def Select16rirr : Pseudo<(outs GEXR16:$dst),
+                  (ins cc:$cc, GEXR16:$lhs, i16imm:$rhs, GEXR16:$trueV, GEXR16:$falseV),
                   "SET\t{$dst, $falseV}\n"
                   "\t$cc\t{$lhs, $rhs}\n"
                   "\tSET\t{$dst, $trueV}",
-                  [(set GR16:$dst,
-                    (DCPU16selectcc imm:$cc, GR16:$lhs, imm:$rhs, GR16:$trueV, GR16:$falseV))]>;
-  def Select16irrr : Pseudo<(outs GR16:$dst),
-                  (ins cc:$cc, i16imm:$lhs, GR16:$rhs, GR16:$trueV, GR16:$falseV),
+                  [(set GEXR16:$dst,
+                    (DCPU16selectcc imm:$cc, GEXR16:$lhs, imm:$rhs, GEXR16:$trueV, GEXR16:$falseV))]>;
+  def Select16irrr : Pseudo<(outs GEXR16:$dst),
+                  (ins cc:$cc, i16imm:$lhs, GEXR16:$rhs, GEXR16:$trueV, GEXR16:$falseV),
                   "SET\t{$dst, $falseV}\n"
                   "\t$cc\t{$lhs, $rhs}\n"
                   "\tSET\t{$dst, $trueV}",
-                  [(set GR16:$dst,
-                    (DCPU16selectcc imm:$cc, imm:$lhs, GR16:$rhs, GR16:$trueV, GR16:$falseV))]>;
+                  [(set GEXR16:$dst,
+                    (DCPU16selectcc imm:$cc, imm:$lhs, GEXR16:$rhs, GEXR16:$trueV, GEXR16:$falseV))]>;
 
-  def Select16rrii : Pseudo<(outs GR16:$dst),
-                  (ins cc:$cc, GR16:$lhs, GR16:$rhs, i16imm:$trueV, i16imm:$falseV),
+  def Select16rrii : Pseudo<(outs GEXR16:$dst),
+                  (ins cc:$cc, GEXR16:$lhs, GEXR16:$rhs, i16imm:$trueV, i16imm:$falseV),
                   "SET\t{$dst, $falseV}\n"
                   "\t$cc\t{$lhs, $rhs}\n"
                   "\tSET\t{$dst, $trueV}",
-                  [(set GR16:$dst,
-                    (DCPU16selectcc imm:$cc, GR16:$lhs, GR16:$rhs, imm:$trueV, imm:$falseV))]>;
-  def Select16riii : Pseudo<(outs GR16:$dst),
-                  (ins cc:$cc, GR16:$lhs, i16imm:$rhs, i16imm:$trueV, i16imm:$falseV),
+                  [(set GEXR16:$dst,
+                    (DCPU16selectcc imm:$cc, GEXR16:$lhs, GEXR16:$rhs, imm:$trueV, imm:$falseV))]>;
+  def Select16riii : Pseudo<(outs GEXR16:$dst),
+                  (ins cc:$cc, GEXR16:$lhs, i16imm:$rhs, i16imm:$trueV, i16imm:$falseV),
                   "SET\t{$dst, $falseV}\n"
                   "\t$cc\t{$lhs, $rhs}\n"
                   "\tSET\t{$dst, $trueV}",
-                  [(set GR16:$dst,
-                    (DCPU16selectcc imm:$cc, GR16:$lhs, imm:$rhs, imm:$trueV, imm:$falseV))]>;
-  def Select16irii : Pseudo<(outs GR16:$dst),
-                  (ins cc:$cc, i16imm:$lhs, GR16:$rhs, i16imm:$trueV, i16imm:$falseV),
+                  [(set GEXR16:$dst,
+                    (DCPU16selectcc imm:$cc, GEXR16:$lhs, imm:$rhs, imm:$trueV, imm:$falseV))]>;
+  def Select16irii : Pseudo<(outs GEXR16:$dst),
+                  (ins cc:$cc, i16imm:$lhs, GEXR16:$rhs, i16imm:$trueV, i16imm:$falseV),
                   "SET\t{$dst, $falseV}\n"
                   "\t$cc\t{$lhs, $rhs}\n"
                   "\tSET\t{$dst, $trueV}",
-                  [(set GR16:$dst,
-                    (DCPU16selectcc imm:$cc, imm:$lhs, GR16:$rhs, imm:$trueV, imm:$falseV))]>;
+                  [(set GEXR16:$dst,
+                    (DCPU16selectcc imm:$cc, imm:$lhs, GEXR16:$rhs, imm:$trueV, imm:$falseV))]>;
 }
 
 let neverHasSideEffects = 1 in
@@ -190,9 +190,9 @@ let isBarrier = 1 in {
     def Bi  : I16ri<0, (outs), (ins i16imm:$brdst),
                     "br\t$brdst",
                     [(brind tblockaddress:$brdst)]>;
-    def Br  : I16rr<0, (outs), (ins GR16:$brdst),
+    def Br  : I16rr<0, (outs), (ins GEXR16:$brdst),
                     "SET\t{pc, $brdst}",
-                    [(brind GR16:$brdst)]>;
+                    [(brind GEXR16:$brdst)]>;
     def Bm  : I16rm<0, (outs), (ins memsrc:$brdst),
                     "SET\t{pc, $brdst}",
                     [(brind (load addr:$brdst))]>;
@@ -202,20 +202,20 @@ let isBarrier = 1 in {
 // Conditional branches
 // TODO: add memory versions
 def BR_CCrr : CJForm<0, 0,
-   (outs), (ins cc:$cc, GR16:$lhs, GR16:$rhs, jmptarget:$dst),
+   (outs), (ins cc:$cc, GEXR16:$lhs, GEXR16:$rhs, jmptarget:$dst),
    "$cc\t{$lhs, $rhs}\n"
    "\tSET\t{PC, $dst}",
-   [(DCPU16brcc imm:$cc, GR16:$lhs, GR16:$rhs, bb:$dst)]>;
+   [(DCPU16brcc imm:$cc, GEXR16:$lhs, GEXR16:$rhs, bb:$dst)]>;
 def BR_CCri : CJForm<0, 0,
-   (outs), (ins cc:$cc, GR16:$lhs, i16imm:$rhs, jmptarget:$dst),
+   (outs), (ins cc:$cc, GEXR16:$lhs, i16imm:$rhs, jmptarget:$dst),
    "$cc\t{$lhs, $rhs}\n"
    "\tSET\t{PC, $dst}",
-   [(DCPU16brcc imm:$cc, GR16:$lhs, imm:$rhs, bb:$dst)]>;
+   [(DCPU16brcc imm:$cc, GEXR16:$lhs, imm:$rhs, bb:$dst)]>;
 def BR_CCir : CJForm<0, 0,
-   (outs), (ins cc:$cc, i16imm:$lhs, GR16:$rhs, jmptarget:$dst),
+   (outs), (ins cc:$cc, i16imm:$lhs, GEXR16:$rhs, jmptarget:$dst),
    "$cc\t{$lhs, $rhs}\n"
    "\tSET\t{PC, $dst}",
-   [(DCPU16brcc imm:$cc, imm:$lhs, GR16:$rhs, bb:$dst)]>;
+   [(DCPU16brcc imm:$cc, imm:$lhs, GEXR16:$rhs, bb:$dst)]>;
 def BR_CCii : CJForm<0, 0,
    (outs), (ins cc:$cc, i16imm:$lhs, i16imm:$rhs, jmptarget:$dst),
    "$cc\t{$lhs, $rhs}\n"
@@ -237,8 +237,8 @@ let isCall = 1 in
                           (outs), (ins i16imm:$dst, variable_ops),
                           "JSR\t$dst", [(DCPU16call imm:$dst)]>;
     def CALLr     : II16r<0x0,
-                          (outs), (ins GR16:$dst, variable_ops),
-                          "JSR\t$dst", [(DCPU16call GR16:$dst)]>;
+                          (outs), (ins GEXR16:$dst, variable_ops),
+                          "JSR\t$dst", [(DCPU16call GEXR16:$dst)]>;
     def CALLm     : II16m<0x0,
                           (outs), (ins memsrc:$dst, variable_ops),
                           "JSR\t${dst:mem}", [(DCPU16call (load addr:$dst))]>;
@@ -251,11 +251,11 @@ let isCall = 1 in
 let Defs = [SP], Uses = [SP], neverHasSideEffects=1 in {
 let mayLoad = 1 in
 def POP16r   : IForm16<0x0, DstReg, SrcPostInc, Size2Bytes,
-                       (outs GR16:$reg), (ins), "SET\t{$reg, POP}", []>;
+                       (outs GEXR16:$reg), (ins), "SET\t{$reg, POP}", []>;
 
 let mayStore = 1 in
 def PUSH16r  : II16r<0x0,
-                     (outs), (ins GR16:$reg), "SET\t{PUSH, $reg}",[]>;
+                     (outs), (ins GEXR16:$reg), "SET\t{PUSH, $reg}",[]>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -264,7 +264,7 @@ def PUSH16r  : II16r<0x0,
 // FIXME: Provide proper encoding!
 let neverHasSideEffects = 1 in {
 def MOV16rr : I16rr<0x0,
-                    (outs GR16:$dst), (ins GR16:$src),
+                    (outs GEXR16:$dst), (ins GEXR16:$src),
                     "SET\t{$dst, $src}",
                     []>;
 }
@@ -272,23 +272,23 @@ def MOV16rr : I16rr<0x0,
 // FIXME: Provide proper encoding!
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in {
 def MOV16ri : I16ri<0x0,
-                    (outs GR16:$dst), (ins i16imm:$src),
+                    (outs GEXR16:$dst), (ins i16imm:$src),
                     "SET\t{$dst, $src}",
-                    [(set GR16:$dst, imm:$src)]>;
+                    [(set GEXR16:$dst, imm:$src)]>;
 }
 
 let canFoldAsLoad = 1, isReMaterializable = 1 in {
 def MOV16rm : I16rm<0x0,
-                    (outs GR16:$dst), (ins memsrc:$src),
+                    (outs GEXR16:$dst), (ins memsrc:$src),
                     "SET\t{$dst, $src}",
-                    [(set GR16:$dst, (load addr:$src))]>;
+                    [(set GEXR16:$dst, (load addr:$src))]>;
 }
 
 let canFoldAsLoad = 1, isReMaterializable = 1 in {
 def MOV16rmi8 : I16rm<0x0,
-                    (outs GR16:$dst), (ins memsrc:$src),
+                    (outs GEXR16:$dst), (ins memsrc:$src),
                     "SET\t{$dst, $src}",
-                    [(set GR16:$dst, (zextloadi8 addr:$src))]>;
+                    [(set GEXR16:$dst, (zextloadi8 addr:$src))]>;
 }
 
 def MOV16mi : I16mi<0x0,
@@ -297,9 +297,9 @@ def MOV16mi : I16mi<0x0,
                     [(store (i16 imm:$src), addr:$dst)]>;
 
 def MOV16mr : I16mr<0x0,
-                    (outs), (ins memdst:$dst, GR16:$src),
+                    (outs), (ins memdst:$dst, GEXR16:$src),
                     "SET\t{$dst, $src}",
-                    [(store GR16:$src, addr:$dst)]>;
+                    [(store GEXR16:$src, addr:$dst)]>;
 
 def MOV16mm : I16mm<0x0,
                     (outs), (ins memdst:$dst, memsrc:$src),
@@ -312,9 +312,9 @@ def MOV16mm : I16mm<0x0,
 multiclass BASIC_RR_IS_COM<bits<4> OpVal, string OpcStr, SDNode OpNode> {
   let Constraints = "$src = $dst", isCommutable = 1 in {
   def rr: I16rr<OpVal,
-                    (outs GR16:$dst), (ins GR16:$src, GR16:$src2),
+                    (outs GR16:$dst), (ins GR16:$src, GEXR16:$src2),
                     OpcStr#"\t{$dst, $src2}",
-                    [(set GR16:$dst, (OpNode GR16:$src, GR16:$src2)),
+                    [(set GR16:$dst, (OpNode GR16:$src, GEXR16:$src2)),
                      (implicit EX)]>;
   }
 }
@@ -322,9 +322,9 @@ multiclass BASIC_RR_IS_COM<bits<4> OpVal, string OpcStr, SDNode OpNode> {
 multiclass BASIC_RR_NON_COM<bits<4> OpVal, string OpcStr, SDNode OpNode> {
   let Constraints = "$src = $dst" in {
   def rr: I16rr<OpVal,
-                    (outs GR16:$dst), (ins GR16:$src, GR16:$src2),
+                    (outs GR16:$dst), (ins GR16:$src, GEXR16:$src2),
                     OpcStr#"\t{$dst, $src2}",
-                    [(set GR16:$dst, (OpNode GR16:$src, GR16:$src2)),
+                    [(set GR16:$dst, (OpNode GR16:$src, GEXR16:$src2)),
                      (implicit EX)]>;
   }
 }
@@ -344,9 +344,9 @@ multiclass BASIC_NORMAL<bits<4> OpVal, string OpcStr, SDNode OpNode> {
   }
   let Constraints = "" in {
   def mr: I16mr<OpVal,
-                    (outs), (ins memdst:$dst, GR16:$src),
+                    (outs), (ins memdst:$dst, GEXR16:$src),
                     OpcStr#"\t{$dst, $src}",
-                    [(store (OpNode (load addr:$dst), GR16:$src), addr:$dst),
+                    [(store (OpNode (load addr:$dst), GEXR16:$src), addr:$dst),
                      (implicit EX)]>;
   def mi: I16mi<OpVal,
                     (outs), (ins memdst:$dst, i16imm:$src),

--- a/lib/Target/DCPU16/DCPU16RegisterInfo.cpp
+++ b/lib/Target/DCPU16/DCPU16RegisterInfo.cpp
@@ -40,7 +40,6 @@ DCPU16RegisterInfo::DCPU16RegisterInfo(DCPU16TargetMachine &tm,
 
 const uint16_t*
 DCPU16RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
-  const TargetFrameLowering *TFI = MF->getTarget().getFrameLowering();
   const Function* F = MF->getFunction();
   static const uint16_t CalleeSavedRegs[] = {
     DCPU16::X, DCPU16::Y, DCPU16::Z, DCPU16::I, DCPU16::J,

--- a/lib/Target/DCPU16/DCPU16RegisterInfo.td
+++ b/lib/Target/DCPU16/DCPU16RegisterInfo.td
@@ -39,9 +39,11 @@ def GR16 : RegisterClass<"DCPU16", [i16], 16,
 // Stack pointer register
 def SPR16 : RegisterClass<"DCPU16", [i16], 16,
   (add SP)>;
-  
+
 // Overflow register
 def EXR16 : RegisterClass<"DCPU16", [i16], 16,
-  (add EX)> {
-   let isAllocatable = 0;
-}
+  (add EX)>;
+
+// Both volatile registers and EX
+def GEXR16 : RegisterClass<"DCPU16", [i16], 16,
+  (add GR16, EXR16)>;

--- a/test/CodeGen/DCPU16/rot.ll
+++ b/test/CodeGen/DCPU16/rot.ll
@@ -1,0 +1,27 @@
+; RUN: llc < %s -march=dcpu16 | FileCheck %s
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
+target triple = "dcpu16"
+
+define i16 @rotl(i16 %a, i16 %b) nounwind readnone {
+entry:
+  %shl = shl i16 %a, %b
+  %sub = sub i16 16, %b
+  %shr = lshr i16 %a, %sub
+  %or = or i16 %shr, %shl
+  ret i16 %or
+}
+; CHECK: :rotl
+; CHECK: SHL A, B
+; CHECK: BOR A, EX
+
+define i16 @rotr(i16 %a, i16 %b) nounwind readnone {
+entry:
+  %sub = sub i16 16, %b
+  %shl = shl i16 %a, %sub
+  %shr = lshr i16 %a, %b
+  %or = or i16 %shl, %shr
+  ret i16 %or
+}
+; CHECK: :rotr
+; CHECK: SHR A, B
+; CHECK: BOR A, EX


### PR DESCRIPTION
See the commits.

I tried to make sure the EX register will not be the target register for instructions that
overwrite EX themselves. IIRC there was a clarification from notch what would happen
in that case, but it just sounds confusing and error prone.

Please tell me if I've overlooked something or if this business can be done in a simpler/
more appropriate manner.
