### PR TITLE
IF* peephole optimisations for #150

### DIFF
--- a/lib/Target/DCPU16/CMakeLists.txt
+++ b/lib/Target/DCPU16/CMakeLists.txt
@@ -20,6 +20,7 @@ add_llvm_target(DCPU16CodeGen
   DCPU16SelectionDAGInfo.cpp
   DCPU16AsmPrinter.cpp
   DCPU16MCInstLower.cpp
+  DCPU16Peephole.cpp
   )
 
 add_subdirectory(InstPrinter)

--- a/lib/Target/DCPU16/DCPU16.h
+++ b/lib/Target/DCPU16/DCPU16.h
@@ -46,8 +46,8 @@ namespace llvm {
   class FunctionPass;
   class formatted_raw_ostream;
 
-  FunctionPass *createDCPU16ISelDag(DCPU16TargetMachine &TM,
-                                    CodeGenOpt::Level OptLevel);
+  FunctionPass *createDCPU16ISelDag(DCPU16TargetMachine &TM, CodeGenOpt::Level OptLevel);
+  FunctionPass *createDCPU16Peephole();
 
 } // end namespace llvm;
 

--- a/lib/Target/DCPU16/DCPU16Peephole.cpp
+++ b/lib/Target/DCPU16/DCPU16Peephole.cpp
@@ -1,0 +1,181 @@
+//===-- DCPU16Peephole.cpp - DCPU16 Peephole Optimiztions ---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// This peephole pass optimizes in the following cases.
+// 1. Optimizes redundant sign extends for the following case
+//    Transform the following pattern
+//    %vreg170<def> = SXTW %vreg166
+//    ...
+//    %vreg176<def> = COPY %vreg170:subreg_loreg
+//
+//    Into
+//    %vreg176<def> = COPY vreg166
+//
+//  2. Optimizes redundant negation of predicates.
+//     %vreg15<def> = CMPGTrr %vreg6, %vreg2
+//     ...
+//     %vreg16<def> = NOT_p %vreg15<kill>
+//     ...
+//     JMP_c %vreg16<kill>, <BB#1>, %PC<imp-def,dead>
+//
+//     Into
+//     %vreg15<def> = CMPGTrr %vreg6, %vreg2;
+//     ...
+//     JMP_cNot %vreg15<kill>, <BB#1>, %PC<imp-def,dead>;
+//
+// Note: The peephole pass makes the instrucstions like
+// %vreg170<def> = SXTW %vreg166 or %vreg16<def> = NOT_p %vreg15<kill>
+// redundant and relies on some form of dead removal instrucions, like
+// DCE or DIE to actually eliminate them.
+
+
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "DCPU16-peephole"
+#include "DCPU16.h"
+#include "DCPU16TargetMachine.h"
+#include "DCPU16InstrInfo.h"
+#include "llvm/Constants.h"
+#include "llvm/PassSupport.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/CodeGen/Passes.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetRegisterInfo.h"
+#include "llvm/Target/TargetInstrInfo.h"
+#include "llvm/MC/MCSymbol.h"
+#include <algorithm>
+#include <iostream>
+
+using namespace llvm;
+
+static cl::opt<bool> DisableDCPU16Peephole("disable-dcpu16-peephole",
+    cl::Hidden, cl::ZeroOrMore, cl::init(false),
+    cl::desc("Disable Peephole Optimization"));
+
+static cl::opt<bool> DisableOptIFA("disable-dcpu16-ifa",
+    cl::Hidden, cl::ZeroOrMore, cl::init(false),
+    cl::desc("Disable IFA Optimization"));
+
+namespace {
+  struct DCPU16Peephole : public MachineFunctionPass {
+    const DCPU16InstrInfo    *QII;
+    const DCPU16RegisterInfo *QRI;
+    const MachineRegisterInfo *MRI;
+
+  public:
+    static char ID;
+    DCPU16Peephole() : MachineFunctionPass(ID) { }
+
+    bool runOnMachineFunction(MachineFunction &MF);
+
+    const char *getPassName() const {
+      return "DCPU16 optimize redundant zero and size extends";
+    }
+
+    void getAnalysisUsage(AnalysisUsage &AU) const {
+      MachineFunctionPass::getAnalysisUsage(AU);
+    }
+  };
+}
+
+char DCPU16Peephole::ID = 0;
+
+bool DCPU16Peephole::runOnMachineFunction(MachineFunction &MF) {
+  QII = static_cast<const DCPU16InstrInfo *>(MF.getTarget().
+                                        getInstrInfo());
+  QRI = static_cast<const DCPU16RegisterInfo *>(MF.getTarget().
+                                       getRegisterInfo());
+  MRI = &MF.getRegInfo();
+
+  DenseMap<unsigned, unsigned> PeepholeMap;
+
+  if (DisableDCPU16Peephole) return false;
+
+  // Loop over all of the basic blocks.
+  for (MachineFunction::iterator MBBb = MF.begin(), MBBe = MF.end();
+       MBBb != MBBe; ++MBBb) {
+    MachineBasicBlock* MBB = MBBb;
+    PeepholeMap.clear();
+    std::cout << std::endl;
+    
+    // Search for AND, IFE
+    
+    if (!DisableOptIFA) {
+      
+      // Traverse the basic block.
+      for (MachineBasicBlock::iterator MII = MBB->begin(); MII != MBB->end();
+                                       ++MII) {
+        MachineInstr *MI = MII;
+        
+        if(!DisableOptIFA && (
+           MI->getOpcode() == DCPU16::AND16rm ||
+           MI->getOpcode() == DCPU16::AND16ri ||
+           MI->getOpcode() == DCPU16::AND16mr ||
+           MI->getOpcode() == DCPU16::AND16mi ||
+           MI->getOpcode() == DCPU16::AND16mm ||
+           MI->getOpcode() == DCPU16::AND16rr
+        )) {
+          switch(MI->getOpcode()) {
+            case DCPU16::AND16ri: {
+              assert (MI->getNumOperands() == 4);
+              
+              MachineOperand &Dst = MI->getOperand(0);
+              MachineOperand &Src  = MI->getOperand(1);
+              unsigned DstReg = Dst.getReg();
+              unsigned SrcReg = Src.getReg();
+              
+              MI->dump();
+              
+              if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
+                TargetRegisterInfo::isVirtualRegister(SrcReg)) {
+                PeepholeMap[DstReg] = SrcReg;
+              }
+            }
+          }
+        }
+
+        MI->dump();
+        
+        if(!DisableOptIFA && (
+           MI->getOpcode() == DCPU16CC::COND_NE
+        )) {
+          switch(MI->getOpcode()) {
+            case DCPU16CC::COND_NE: {
+              /*assert (MI->getNumOperands() == 4);
+              
+              MachineOperand &Dst = MI->getOperand(0);
+              MachineOperand &Src  = MI->getOperand(1);
+              unsigned DstReg = Dst.getReg();
+              unsigned SrcReg = Src.getReg();
+              
+              
+              
+              if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
+                TargetRegisterInfo::isVirtualRegister(SrcReg)) {
+                PeepholeMap[DstReg] = SrcReg;
+              }*/
+            }
+          }
+        }
+      } // Instruction
+    }
+  } // Basic Block
+  return true;
+}
+
+FunctionPass *llvm::createDCPU16Peephole() {
+  return new DCPU16Peephole();
+}
+

--- a/lib/Target/DCPU16/DCPU16Peephole.cpp
+++ b/lib/Target/DCPU16/DCPU16Peephole.cpp
@@ -6,33 +6,8 @@
 // License. See LICENSE.TXT for details.
 //
 // This peephole pass optimizes in the following cases.
-// 1. Optimizes redundant sign extends for the following case
-//    Transform the following pattern
-//    %vreg170<def> = SXTW %vreg166
-//    ...
-//    %vreg176<def> = COPY %vreg170:subreg_loreg
+// 1. Optimises redundant AND+IFE/IFN patterns
 //
-//    Into
-//    %vreg176<def> = COPY vreg166
-//
-//  2. Optimizes redundant negation of predicates.
-//     %vreg15<def> = CMPGTrr %vreg6, %vreg2
-//     ...
-//     %vreg16<def> = NOT_p %vreg15<kill>
-//     ...
-//     JMP_c %vreg16<kill>, <BB#1>, %PC<imp-def,dead>
-//
-//     Into
-//     %vreg15<def> = CMPGTrr %vreg6, %vreg2;
-//     ...
-//     JMP_cNot %vreg15<kill>, <BB#1>, %PC<imp-def,dead>;
-//
-// Note: The peephole pass makes the instrucstions like
-// %vreg170<def> = SXTW %vreg166 or %vreg16<def> = NOT_p %vreg15<kill>
-// redundant and relies on some form of dead removal instrucions, like
-// DCE or DIE to actually eliminate them.
-
-
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "DCPU16-peephole"
@@ -152,9 +127,6 @@ bool DCPU16Peephole::swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr) 
 
 void DCPU16Peephole::runOptBrcc(MachineBasicBlock *mbb) {  
   DenseMap<unsigned, MachineInstr *> peepholeMap;
-  
-  mbb->dump();
-  std::cout << std::endl;
   
   for(MachineBasicBlock::iterator miiIter = mbb->begin(); miiIter != mbb->end(); ++miiIter) {
     MachineInstr *instruction = miiIter;  

--- a/lib/Target/DCPU16/DCPU16Peephole.cpp
+++ b/lib/Target/DCPU16/DCPU16Peephole.cpp
@@ -83,7 +83,7 @@ bool DCPU16Peephole::swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr) 
   MachineOperand &andA = andInstr->getOperand(1);
   MachineOperand &andB = andInstr->getOperand(2);
   
-  if(brA.isReg() && andA.isReg() && brB.isReg() && andB.isReg()) {
+  if(andB.isReg()) {
     brA.ChangeToRegister(
       andA.getReg(),
       andA.isDef(),
@@ -105,7 +105,7 @@ bool DCPU16Peephole::swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr) 
     );
     
     return true;
-  } else if(brA.isReg() && andA.isReg() && brB.isImm() && andB.isImm()) {
+  } else if(andB.isImm()) {
     brA.ChangeToRegister(
       andA.getReg(),
       andA.isDef(),
@@ -116,7 +116,7 @@ bool DCPU16Peephole::swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr) 
       andA.isDebug()
     );
     
-    brB.setImm(andB.getImm());
+    brB.ChangeToImmediate(andB.getImm());
     
     return true;
   } else {
@@ -133,7 +133,8 @@ void DCPU16Peephole::runOptBrcc(MachineBasicBlock *mbb) {
     
     switch(instruction->getOpcode()) {
       // And instructions
-      case DCPU16::AND16ri: {
+      case DCPU16::AND16ri:
+      case DCPU16::AND16rr: {
         assert(instruction->getNumOperands() == 4);
         
         MachineOperand &result = instruction->getOperand(0);

--- a/lib/Target/DCPU16/DCPU16Peephole.cpp
+++ b/lib/Target/DCPU16/DCPU16Peephole.cpp
@@ -120,7 +120,7 @@ bool DCPU16Peephole::swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr) 
     
     return true;
   } else {
-    assert("Encountered unexpected combination in swapOptBrcc");
+    assert(0 && "Encountered unexpected combination in swapOptBrcc");
     return false;
   }
 }

--- a/lib/Target/DCPU16/DCPU16Peephole.cpp
+++ b/lib/Target/DCPU16/DCPU16Peephole.cpp
@@ -120,7 +120,7 @@ bool DCPU16Peephole::swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr) 
     
     return true;
   } else {
-    assert(0 && "Encountered unexpected combination in swapOptBrcc");
+    llvm_unreachable("Encountered unexpected combination in swapOptBrcc");
     return false;
   }
 }

--- a/lib/Target/DCPU16/DCPU16Peephole.cpp
+++ b/lib/Target/DCPU16/DCPU16Peephole.cpp
@@ -1,31 +1,31 @@
 //===-- DCPU16Peephole.cpp - DCPU16 Peephole Optimiztions ---------------===//
 //
-//										 The LLVM Compiler Infrastructure
+//                     The LLVM Compiler Infrastructure
 //
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
 //
 // This peephole pass optimizes in the following cases.
 // 1. Optimizes redundant sign extends for the following case
-//		Transform the following pattern
-//		%vreg170<def> = SXTW %vreg166
-//		...
-//		%vreg176<def> = COPY %vreg170:subreg_loreg
+//    Transform the following pattern
+//    %vreg170<def> = SXTW %vreg166
+//    ...
+//    %vreg176<def> = COPY %vreg170:subreg_loreg
 //
-//		Into
-//		%vreg176<def> = COPY vreg166
+//    Into
+//    %vreg176<def> = COPY vreg166
 //
-//	2. Optimizes redundant negation of predicates.
-//		 %vreg15<def> = CMPGTrr %vreg6, %vreg2
-//		 ...
-//		 %vreg16<def> = NOT_p %vreg15<kill>
-//		 ...
-//		 JMP_c %vreg16<kill>, <BB#1>, %PC<imp-def,dead>
+//  2. Optimizes redundant negation of predicates.
+//     %vreg15<def> = CMPGTrr %vreg6, %vreg2
+//     ...
+//     %vreg16<def> = NOT_p %vreg15<kill>
+//     ...
+//     JMP_c %vreg16<kill>, <BB#1>, %PC<imp-def,dead>
 //
-//		 Into
-//		 %vreg15<def> = CMPGTrr %vreg6, %vreg2;
-//		 ...
-//		 JMP_cNot %vreg15<kill>, <BB#1>, %PC<imp-def,dead>;
+//     Into
+//     %vreg15<def> = CMPGTrr %vreg6, %vreg2;
+//     ...
+//     JMP_cNot %vreg15<kill>, <BB#1>, %PC<imp-def,dead>;
 //
 // Note: The peephole pass makes the instrucstions like
 // %vreg170<def> = SXTW %vreg166 or %vreg16<def> = NOT_p %vreg15<kill>
@@ -61,202 +61,174 @@
 using namespace llvm;
 
 static cl::opt<bool> DisableDCPU16Peephole(
-	"disable-dcpu16-peephole",
-	cl::Hidden,
-	cl::ZeroOrMore,
-	cl::init(false),
-	cl::desc("Disable Peephole Optimisations")
+  "disable-dcpu16-peephole",
+  cl::Hidden,
+  cl::ZeroOrMore,
+  cl::init(false),
+  cl::desc("Disable Peephole Optimisations")
 );
 
 static cl::opt<bool> DisableOptBrcc(
-	"disable-dcpu16-brcc",
-	cl::Hidden, cl::ZeroOrMore, cl::init(false),
-	cl::desc("Disable Conditional Branch Optimization")
+  "disable-dcpu16-brcc",
+  cl::Hidden, cl::ZeroOrMore, cl::init(false),
+  cl::desc("Disable Conditional Branch Optimization")
 );
 
 namespace {
-	struct DCPU16Peephole : public MachineFunctionPass {
-		const DCPU16InstrInfo		*QII;
-		const DCPU16RegisterInfo	*QRI;
-		const MachineRegisterInfo	*MRI;
+  struct DCPU16Peephole : public MachineFunctionPass {
+    const DCPU16InstrInfo    *QII;
+    const DCPU16RegisterInfo  *QRI;
+    const MachineRegisterInfo  *MRI;
 
-	public:
-		static char ID;
-		DCPU16Peephole() : MachineFunctionPass(ID) { }
+  public:
+    static char ID;
+    DCPU16Peephole() : MachineFunctionPass(ID) { }
 
-		bool runOnMachineFunction(MachineFunction &MF);
-		void runOptBrcc(MachineBasicBlock *mbb);
+    bool runOnMachineFunction(MachineFunction &MF);
+    void runOptBrcc(MachineBasicBlock *mbb);
+    bool swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr);
 
-		const char *getPassName() const {
-			return "DCPU16 optimize conditional branches";
-		}
+    const char *getPassName() const {
+      return "DCPU16 optimize conditional branches";
+    }
 
-		void getAnalysisUsage(AnalysisUsage &AU) const {
-			MachineFunctionPass::getAnalysisUsage(AU);
-		}
-	};
+    void getAnalysisUsage(AnalysisUsage &AU) const {
+      MachineFunctionPass::getAnalysisUsage(AU);
+    }
+  };
 }
 
 char DCPU16Peephole::ID = 0;
 
+bool DCPU16Peephole::swapOptBrcc(MachineInstr *brInstr, MachineInstr *andInstr) {
+  MachineOperand &brA = brInstr->getOperand(1);
+  MachineOperand &brB = brInstr->getOperand(2);
+  MachineOperand &andA = andInstr->getOperand(1);
+  MachineOperand &andB = andInstr->getOperand(2);
+  
+  if(brA.isReg() && andA.isReg() && brB.isReg() && andB.isReg()) {
+    brA.setReg(andA.getReg());
+    brB.setReg(andB.getReg());
+    return true;
+  } else if(brA.isReg() && andA.isReg() && brB.isImm() && andB.isImm()) {
+    brA.setReg(andA.getReg());
+    brB.setImm(andB.getImm());
+    return true;
+  } else {
+    assert("Encountered unexpected combination in swapOptBrcc");
+    return false;
+  }
+}
+
 void DCPU16Peephole::runOptBrcc(MachineBasicBlock *mbb) {
-	// Dump the block (remove when done)
-	mbb->dump();
-	std::cout << std::endl;
-	
-	DenseMap<unsigned, MachineInstr *> peepholeMap;
-	
-	for(MachineBasicBlock::iterator miiIter = mbb->begin(); miiIter != mbb->end(); ++miiIter) {
-		MachineInstr *instruction = miiIter;	
-		
-		switch(instruction->getOpcode()) {
-			// And instructions
-			// AND register, immediate
-			case DCPU16::AND16ri: {
-				assert(instruction->getNumOperands() == 4);
-				
-				// %vreg1<def> = AND16ri %vreg0, [immediate], %EX<imp-def,dead>; GR16:%vreg1,%vreg0
-				MachineOperand &result = instruction->getOperand(0);
-				unsigned resultReg = result.getReg();
-				
-				if(TargetRegisterInfo::isVirtualRegister(resultReg))
-					peepholeMap[resultReg] = instruction;
-				
-				break;
-			}
-			
-			// Branch instructions
-			case DCPU16::BR_CCri: {
-				switch(instruction->getOperand(0).getImm()) {
-					case DCPU16CC::COND_NE: {
-						assert(instruction->getNumOperands() == 4);
-						
-						// BR_CCri 3, %vreg1, 0, <BB#2>; GR16:%vreg1
-						MachineOperand &brImm = instruction->getOperand(0);
-						MachineOperand &oldA = instruction->getOperand(1);
-						MachineOperand &oldB = instruction->getOperand(2);
-						if(oldB.getImm() != 0) break; // lhs == 0
-						
-						MachineOperand &regOperand = instruction->getOperand(1);
-						unsigned vReg = regOperand.getReg();
-						
-						if(TargetRegisterInfo::isVirtualRegister(vReg)) {
-							if(MachineInstr *peepholeSource = peepholeMap.lookup(vReg)) {
-								MachineOperand &newA = peepholeSource->getOperand(1);
-								MachineOperand &newB = peepholeSource->getOperand(2);
-								assert(newA.isReg() && newB.isImm() && "Encountered wrong operands in DCPU-16 BR_CCri peephole opt");
-								
-								unsigned vReg = regOperand.getReg();
-								
-								// Change the IFN to IFB and swap the operands
-								brImm.setImm(DCPU16CC::COND_B);
-								oldA.setReg(newA.getReg());
-								oldB.setImm(newB.getImm());
-								
-								// Remove the AND
-								peepholeSource->eraseFromParent();
-								
-								std::cout << "Changed to:" << std::endl;
-								instruction->dump();
-								std::cout << std::endl;
-							}
-						}
-						
-						break;
-					}
-				}
-			}
-		}
-	}
+  // Dump the block (remove when done)
+  mbb->dump();
+  std::cout << std::endl;
+  
+  DenseMap<unsigned, MachineInstr *> peepholeMap;
+  
+  for(MachineBasicBlock::iterator miiIter = mbb->begin(); miiIter != mbb->end(); ++miiIter) {
+    MachineInstr *instruction = miiIter;  
+    
+    switch(instruction->getOpcode()) {
+      // And instructions
+      case DCPU16::AND16rr:
+      case DCPU16::AND16ri: {
+        assert(instruction->getNumOperands() == 4);
+        
+        MachineOperand &result = instruction->getOperand(0);
+        unsigned resultReg = result.getReg();
+        
+        if(TargetRegisterInfo::isVirtualRegister(resultReg))
+          peepholeMap[resultReg] = instruction;
+        
+        break;
+      }
+      
+      // Branch instructions
+      case DCPU16::BR_CCri: {
+        switch(instruction->getOperand(0).getImm()) {
+          case DCPU16CC::COND_NE: {
+            assert(instruction->getNumOperands() == 4);
+            
+            if(instruction->getOperand(2).getImm() != 0) break; // Only works if comparing to 0
+            
+            unsigned activeReg = instruction->getOperand(1).getReg();
+            
+            if(MachineInstr *peepholeSource = peepholeMap.lookup(activeReg)) {
+              std::cout << "--------------------------------------------------------" << std::endl;
+              std::cout << "Optimisation opportunity:" << std::endl;
+              peepholeSource->dump();
+              instruction->dump();
+              std::cout << std::endl;
+              
+              // Change the IFN to IFB and swap the operands
+              instruction->getOperand(0).setImm(DCPU16CC::COND_B);
+              swapOptBrcc(instruction, peepholeSource);
+              
+              // Remove the AND from the block
+              peepholeSource->eraseFromParent();
+              
+              std::cout << "Changed to:" << std::endl;
+              instruction->dump();
+              std::cout << "--------------------------------------------------------" << std::endl << std::endl;;
+            }
+            
+            break;
+          }
+          
+          case DCPU16CC::COND_E: {
+            assert(instruction->getNumOperands() == 4);
+            
+            if(instruction->getOperand(2).getImm() != 0) break; // Only works if comparing to 0
+            
+            unsigned activeReg = instruction->getOperand(1).getReg();
+            
+            if(MachineInstr *peepholeSource = peepholeMap.lookup(activeReg)) {
+              std::cout << "--------------------------------------------------------" << std::endl;
+              std::cout << "Optimisation opportunity:" << std::endl;
+              peepholeSource->dump();
+              instruction->dump();
+              std::cout << std::endl;
+              
+              // Change the IFN to IFB and swap the operands
+              instruction->getOperand(0).setImm(DCPU16CC::COND_C);
+              swapOptBrcc(instruction, peepholeSource);
+              
+              // Remove the AND from the block
+              peepholeSource->eraseFromParent();
+              
+              std::cout << "Changed to:" << std::endl;
+              instruction->dump();
+              std::cout << "--------------------------------------------------------" << std::endl << std::endl;;
+            }
+            
+            break;
+          }
+        }
+      }
+    }
+  }
 }
 
 bool DCPU16Peephole::runOnMachineFunction(MachineFunction &MF) {
-	QII = static_cast<const DCPU16InstrInfo *>(MF.getTarget().getInstrInfo());
-	QRI = static_cast<const DCPU16RegisterInfo *>(MF.getTarget().getRegisterInfo());
-	MRI = &MF.getRegInfo();
-	
-	// Disable all peephole optimisations
-	if(DisableDCPU16Peephole) return false;
+  QII = static_cast<const DCPU16InstrInfo *>(MF.getTarget().getInstrInfo());
+  QRI = static_cast<const DCPU16RegisterInfo *>(MF.getTarget().getRegisterInfo());
+  MRI = &MF.getRegInfo();
+  
+  // Disable all peephole optimisations
+  if(DisableDCPU16Peephole) return false;
 
-	// Loop over all of the basic blocks.
-	for(MachineFunction::iterator mbbIter = MF.begin(); mbbIter != MF.end(); ++mbbIter) {
-		MachineBasicBlock *mbb = mbbIter;
-		
-		if(!DisableOptBrcc) runOptBrcc(mbb);
-		
-		/*// Search for AND, IFE
-		if (!DisableOptIFA) {
-			
-			// Traverse the basic block.
-			for (MachineBasicBlock::iterator MII = MBB->begin(); MII != MBB->end();
-																			 ++MII) {
-				MachineInstr *MI = MII;
-				
-				if (!DisableOptIFA && (
-					 MI->getOpcode() == DCPU16::AND16rm ||
-					 MI->getOpcode() == DCPU16::AND16ri ||
-					 MI->getOpcode() == DCPU16::AND16mr ||
-					 MI->getOpcode() == DCPU16::AND16mi ||
-					 MI->getOpcode() == DCPU16::AND16mm ||
-					 MI->getOpcode() == DCPU16::AND16rr
-				)) {
-					switch(MI->getOpcode()) {
-						case DCPU16::AND16ri: {
-							assert (MI->getNumOperands() == 4);
-							
-							MachineOperand &Dst = MI->getOperand(0);
-							MachineOperand &Src	= MI->getOperand(1);
-							unsigned DstReg = Dst.getReg();
-							unsigned SrcReg = Src.getReg();
-							
-							if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
-								TargetRegisterInfo::isVirtualRegister(SrcReg)) {
-								PeepholeMap[DstReg] = SrcReg;
-							}
-						}
-					}
-				}
-				
-				if (!DisableOptIFA && (
-					 MI->getOpcode() == DCPU16::BR_CCri
-				)) {
-					switch (MI->getOperand(0).getImm()) {
-						case DCPU16CC::COND_NE: {
-							assert (MI->getNumOperands() == 4);
-							
-							if (MI->getOperand(2).getImm() != 0) break;
-							
-							MachineOperand &Src = MI->getOperand(1);
-							unsigned SrcReg = Src.getReg();
-							
-							if (TargetRegisterInfo::isVirtualRegister(SrcReg)) {
-								// Try to find in the map.
-								if (unsigned PeepholeSrc = PeepholeMap.lookup(SrcReg)) {
-									// Change the 1st operand.
-									MI->RemoveOperand(3);
-									MI->addOperand(MachineOperand::CreateImm(53264));
-									
-									std::cout << std::endl;
-									std::cout << "Optimise here plz" << std::endl;
-									MI->dump();
-									std::cout << std::endl;
-								}
-							}
-							
-							if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
-								TargetRegisterInfo::isVirtualRegister(SrcReg)) {
-								PeepholeMap[DstReg] = SrcReg;
-							}
-						}
-					}
-				}
-			} // Instruction
-		}*/
-	} // Basic Block
-	return true;
+  // Loop over all of the basic blocks.
+  for(MachineFunction::iterator mbbIter = MF.begin(); mbbIter != MF.end(); ++mbbIter) {
+    MachineBasicBlock *mbb = mbbIter;
+    
+    if(!DisableOptBrcc) runOptBrcc(mbb);
+  } // Basic Block
+  return true;
 }
 
 FunctionPass *llvm::createDCPU16Peephole() {
-	return new DCPU16Peephole();
+  return new DCPU16Peephole();
 }
 

--- a/lib/Target/DCPU16/DCPU16Peephole.cpp
+++ b/lib/Target/DCPU16/DCPU16Peephole.cpp
@@ -1,31 +1,31 @@
 //===-- DCPU16Peephole.cpp - DCPU16 Peephole Optimiztions ---------------===//
 //
-//                     The LLVM Compiler Infrastructure
+//										 The LLVM Compiler Infrastructure
 //
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
 //
 // This peephole pass optimizes in the following cases.
 // 1. Optimizes redundant sign extends for the following case
-//    Transform the following pattern
-//    %vreg170<def> = SXTW %vreg166
-//    ...
-//    %vreg176<def> = COPY %vreg170:subreg_loreg
+//		Transform the following pattern
+//		%vreg170<def> = SXTW %vreg166
+//		...
+//		%vreg176<def> = COPY %vreg170:subreg_loreg
 //
-//    Into
-//    %vreg176<def> = COPY vreg166
+//		Into
+//		%vreg176<def> = COPY vreg166
 //
-//  2. Optimizes redundant negation of predicates.
-//     %vreg15<def> = CMPGTrr %vreg6, %vreg2
-//     ...
-//     %vreg16<def> = NOT_p %vreg15<kill>
-//     ...
-//     JMP_c %vreg16<kill>, <BB#1>, %PC<imp-def,dead>
+//	2. Optimizes redundant negation of predicates.
+//		 %vreg15<def> = CMPGTrr %vreg6, %vreg2
+//		 ...
+//		 %vreg16<def> = NOT_p %vreg15<kill>
+//		 ...
+//		 JMP_c %vreg16<kill>, <BB#1>, %PC<imp-def,dead>
 //
-//     Into
-//     %vreg15<def> = CMPGTrr %vreg6, %vreg2;
-//     ...
-//     JMP_cNot %vreg15<kill>, <BB#1>, %PC<imp-def,dead>;
+//		 Into
+//		 %vreg15<def> = CMPGTrr %vreg6, %vreg2;
+//		 ...
+//		 JMP_cNot %vreg15<kill>, <BB#1>, %PC<imp-def,dead>;
 //
 // Note: The peephole pass makes the instrucstions like
 // %vreg170<def> = SXTW %vreg166 or %vreg16<def> = NOT_p %vreg15<kill>
@@ -60,122 +60,203 @@
 
 using namespace llvm;
 
-static cl::opt<bool> DisableDCPU16Peephole("disable-dcpu16-peephole",
-    cl::Hidden, cl::ZeroOrMore, cl::init(false),
-    cl::desc("Disable Peephole Optimization"));
+static cl::opt<bool> DisableDCPU16Peephole(
+	"disable-dcpu16-peephole",
+	cl::Hidden,
+	cl::ZeroOrMore,
+	cl::init(false),
+	cl::desc("Disable Peephole Optimisations")
+);
 
-static cl::opt<bool> DisableOptIFA("disable-dcpu16-ifa",
-    cl::Hidden, cl::ZeroOrMore, cl::init(false),
-    cl::desc("Disable IFA Optimization"));
+static cl::opt<bool> DisableOptBrcc(
+	"disable-dcpu16-brcc",
+	cl::Hidden, cl::ZeroOrMore, cl::init(false),
+	cl::desc("Disable Conditional Branch Optimization")
+);
 
 namespace {
-  struct DCPU16Peephole : public MachineFunctionPass {
-    const DCPU16InstrInfo    *QII;
-    const DCPU16RegisterInfo *QRI;
-    const MachineRegisterInfo *MRI;
+	struct DCPU16Peephole : public MachineFunctionPass {
+		const DCPU16InstrInfo		*QII;
+		const DCPU16RegisterInfo	*QRI;
+		const MachineRegisterInfo	*MRI;
 
-  public:
-    static char ID;
-    DCPU16Peephole() : MachineFunctionPass(ID) { }
+	public:
+		static char ID;
+		DCPU16Peephole() : MachineFunctionPass(ID) { }
 
-    bool runOnMachineFunction(MachineFunction &MF);
+		bool runOnMachineFunction(MachineFunction &MF);
+		void runOptBrcc(MachineBasicBlock *mbb);
 
-    const char *getPassName() const {
-      return "DCPU16 optimize redundant zero and size extends";
-    }
+		const char *getPassName() const {
+			return "DCPU16 optimize conditional branches";
+		}
 
-    void getAnalysisUsage(AnalysisUsage &AU) const {
-      MachineFunctionPass::getAnalysisUsage(AU);
-    }
-  };
+		void getAnalysisUsage(AnalysisUsage &AU) const {
+			MachineFunctionPass::getAnalysisUsage(AU);
+		}
+	};
 }
 
 char DCPU16Peephole::ID = 0;
 
+void DCPU16Peephole::runOptBrcc(MachineBasicBlock *mbb) {
+	// Dump the block (remove when done)
+	mbb->dump();
+	std::cout << std::endl;
+	
+	DenseMap<unsigned, MachineInstr *> peepholeMap;
+	
+	for(MachineBasicBlock::iterator miiIter = mbb->begin(); miiIter != mbb->end(); ++miiIter) {
+		MachineInstr *instruction = miiIter;	
+		
+		switch(instruction->getOpcode()) {
+			// And instructions
+			// AND register, immediate
+			case DCPU16::AND16ri: {
+				assert(instruction->getNumOperands() == 4);
+				
+				// %vreg1<def> = AND16ri %vreg0, [immediate], %EX<imp-def,dead>; GR16:%vreg1,%vreg0
+				MachineOperand &result = instruction->getOperand(0);
+				unsigned resultReg = result.getReg();
+				
+				if(TargetRegisterInfo::isVirtualRegister(resultReg))
+					peepholeMap[resultReg] = instruction;
+				
+				break;
+			}
+			
+			// Branch instructions
+			case DCPU16::BR_CCri: {
+				switch(instruction->getOperand(0).getImm()) {
+					case DCPU16CC::COND_NE: {
+						assert(instruction->getNumOperands() == 4);
+						
+						// BR_CCri 3, %vreg1, 0, <BB#2>; GR16:%vreg1
+						MachineOperand &brImm = instruction->getOperand(0);
+						MachineOperand &oldA = instruction->getOperand(1);
+						MachineOperand &oldB = instruction->getOperand(2);
+						if(oldB.getImm() != 0) break; // lhs == 0
+						
+						MachineOperand &regOperand = instruction->getOperand(1);
+						unsigned vReg = regOperand.getReg();
+						
+						if(TargetRegisterInfo::isVirtualRegister(vReg)) {
+							if(MachineInstr *peepholeSource = peepholeMap.lookup(vReg)) {
+								MachineOperand &newA = peepholeSource->getOperand(1);
+								MachineOperand &newB = peepholeSource->getOperand(2);
+								assert(newA.isReg() && newB.isImm() && "Encountered wrong operands in DCPU-16 BR_CCri peephole opt");
+								
+								unsigned vReg = regOperand.getReg();
+								
+								// Change the IFN to IFB and swap the operands
+								brImm.setImm(DCPU16CC::COND_B);
+								oldA.setReg(newA.getReg());
+								oldB.setImm(newB.getImm());
+								
+								// Remove the AND
+								peepholeSource->eraseFromParent();
+								
+								std::cout << "Changed to:" << std::endl;
+								instruction->dump();
+								std::cout << std::endl;
+							}
+						}
+						
+						break;
+					}
+				}
+			}
+		}
+	}
+}
+
 bool DCPU16Peephole::runOnMachineFunction(MachineFunction &MF) {
-  QII = static_cast<const DCPU16InstrInfo *>(MF.getTarget().
-                                        getInstrInfo());
-  QRI = static_cast<const DCPU16RegisterInfo *>(MF.getTarget().
-                                       getRegisterInfo());
-  MRI = &MF.getRegInfo();
+	QII = static_cast<const DCPU16InstrInfo *>(MF.getTarget().getInstrInfo());
+	QRI = static_cast<const DCPU16RegisterInfo *>(MF.getTarget().getRegisterInfo());
+	MRI = &MF.getRegInfo();
+	
+	// Disable all peephole optimisations
+	if(DisableDCPU16Peephole) return false;
 
-  DenseMap<unsigned, unsigned> PeepholeMap;
-
-  if (DisableDCPU16Peephole) return false;
-
-  // Loop over all of the basic blocks.
-  for (MachineFunction::iterator MBBb = MF.begin(), MBBe = MF.end();
-       MBBb != MBBe; ++MBBb) {
-    MachineBasicBlock* MBB = MBBb;
-    PeepholeMap.clear();
-    std::cout << std::endl;
-    
-    // Search for AND, IFE
-    
-    if (!DisableOptIFA) {
-      
-      // Traverse the basic block.
-      for (MachineBasicBlock::iterator MII = MBB->begin(); MII != MBB->end();
-                                       ++MII) {
-        MachineInstr *MI = MII;
-        
-        if(!DisableOptIFA && (
-           MI->getOpcode() == DCPU16::AND16rm ||
-           MI->getOpcode() == DCPU16::AND16ri ||
-           MI->getOpcode() == DCPU16::AND16mr ||
-           MI->getOpcode() == DCPU16::AND16mi ||
-           MI->getOpcode() == DCPU16::AND16mm ||
-           MI->getOpcode() == DCPU16::AND16rr
-        )) {
-          switch(MI->getOpcode()) {
-            case DCPU16::AND16ri: {
-              assert (MI->getNumOperands() == 4);
-              
-              MachineOperand &Dst = MI->getOperand(0);
-              MachineOperand &Src  = MI->getOperand(1);
-              unsigned DstReg = Dst.getReg();
-              unsigned SrcReg = Src.getReg();
-              
-              MI->dump();
-              
-              if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
-                TargetRegisterInfo::isVirtualRegister(SrcReg)) {
-                PeepholeMap[DstReg] = SrcReg;
-              }
-            }
-          }
-        }
-
-        MI->dump();
-        
-        if(!DisableOptIFA && (
-           MI->getOpcode() == DCPU16CC::COND_NE
-        )) {
-          switch(MI->getOpcode()) {
-            case DCPU16CC::COND_NE: {
-              /*assert (MI->getNumOperands() == 4);
-              
-              MachineOperand &Dst = MI->getOperand(0);
-              MachineOperand &Src  = MI->getOperand(1);
-              unsigned DstReg = Dst.getReg();
-              unsigned SrcReg = Src.getReg();
-              
-              
-              
-              if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
-                TargetRegisterInfo::isVirtualRegister(SrcReg)) {
-                PeepholeMap[DstReg] = SrcReg;
-              }*/
-            }
-          }
-        }
-      } // Instruction
-    }
-  } // Basic Block
-  return true;
+	// Loop over all of the basic blocks.
+	for(MachineFunction::iterator mbbIter = MF.begin(); mbbIter != MF.end(); ++mbbIter) {
+		MachineBasicBlock *mbb = mbbIter;
+		
+		if(!DisableOptBrcc) runOptBrcc(mbb);
+		
+		/*// Search for AND, IFE
+		if (!DisableOptIFA) {
+			
+			// Traverse the basic block.
+			for (MachineBasicBlock::iterator MII = MBB->begin(); MII != MBB->end();
+																			 ++MII) {
+				MachineInstr *MI = MII;
+				
+				if (!DisableOptIFA && (
+					 MI->getOpcode() == DCPU16::AND16rm ||
+					 MI->getOpcode() == DCPU16::AND16ri ||
+					 MI->getOpcode() == DCPU16::AND16mr ||
+					 MI->getOpcode() == DCPU16::AND16mi ||
+					 MI->getOpcode() == DCPU16::AND16mm ||
+					 MI->getOpcode() == DCPU16::AND16rr
+				)) {
+					switch(MI->getOpcode()) {
+						case DCPU16::AND16ri: {
+							assert (MI->getNumOperands() == 4);
+							
+							MachineOperand &Dst = MI->getOperand(0);
+							MachineOperand &Src	= MI->getOperand(1);
+							unsigned DstReg = Dst.getReg();
+							unsigned SrcReg = Src.getReg();
+							
+							if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
+								TargetRegisterInfo::isVirtualRegister(SrcReg)) {
+								PeepholeMap[DstReg] = SrcReg;
+							}
+						}
+					}
+				}
+				
+				if (!DisableOptIFA && (
+					 MI->getOpcode() == DCPU16::BR_CCri
+				)) {
+					switch (MI->getOperand(0).getImm()) {
+						case DCPU16CC::COND_NE: {
+							assert (MI->getNumOperands() == 4);
+							
+							if (MI->getOperand(2).getImm() != 0) break;
+							
+							MachineOperand &Src = MI->getOperand(1);
+							unsigned SrcReg = Src.getReg();
+							
+							if (TargetRegisterInfo::isVirtualRegister(SrcReg)) {
+								// Try to find in the map.
+								if (unsigned PeepholeSrc = PeepholeMap.lookup(SrcReg)) {
+									// Change the 1st operand.
+									MI->RemoveOperand(3);
+									MI->addOperand(MachineOperand::CreateImm(53264));
+									
+									std::cout << std::endl;
+									std::cout << "Optimise here plz" << std::endl;
+									MI->dump();
+									std::cout << std::endl;
+								}
+							}
+							
+							if (TargetRegisterInfo::isVirtualRegister(DstReg) &&
+								TargetRegisterInfo::isVirtualRegister(SrcReg)) {
+								PeepholeMap[DstReg] = SrcReg;
+							}
+						}
+					}
+				}
+			} // Instruction
+		}*/
+	} // Basic Block
+	return true;
 }
 
 FunctionPass *llvm::createDCPU16Peephole() {
-  return new DCPU16Peephole();
+	return new DCPU16Peephole();
 }
 

--- a/lib/Target/DCPU16/DCPU16TargetMachine.cpp
+++ b/lib/Target/DCPU16/DCPU16TargetMachine.cpp
@@ -61,5 +61,7 @@ TargetPassConfig *DCPU16TargetMachine::createPassConfig(PassManagerBase &PM) {
 bool DCPU16PassConfig::addInstSelector() {
   // Install an instruction selector.
   PM->add(createDCPU16ISelDag(getDCPU16TargetMachine(), getOptLevel()));
+  // Peephole optimisations
+  PM->add(createDCPU16Peephole());
   return false;
 }

--- a/test/CodeGen/DCPU16/brccand.ll
+++ b/test/CodeGen/DCPU16/brccand.ll
@@ -1,0 +1,67 @@
+; RUN: llc < %s -march=dcpu16 -O0 | FileCheck %s
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
+target triple = "dcpu16"
+
+define i16 @brccand_nested() nounwind {
+entry:
+  %retval = alloca i16, align 1
+  %a = alloca i16, align 1
+  %b = alloca i16, align 1
+  store i16 1, i16* %a, align 1
+  store i16 2, i16* %b, align 1
+  %0 = load i16* %a, align 1
+  %1 = load i16* %b, align 1
+  %and = and i16 %0, %1
+  %cmp = icmp eq i16 %and, 0
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  %2 = load i16* %b, align 1
+  %3 = load i16* %a, align 1
+  %and1 = and i16 %2, %3
+  %cmp2 = icmp ne i16 %and1, 0
+  br i1 %cmp2, label %if.then3, label %if.else
+
+if.then3:                                         ; preds = %if.then
+  store i16 2, i16* %retval
+  br label %return
+
+if.else:                                          ; preds = %if.then
+  store i16 1, i16* %retval
+  br label %return
+
+if.end:                                           ; preds = %entry
+  store i16 0, i16* %retval
+  br label %return
+
+return:                                           ; preds = %if.end, %if.else, %if.then3
+  %4 = load i16* %retval
+  ret i16 %4
+}
+
+; CHECK: :brccand_nested
+; CHECK: SUB SP, 0x3
+; CHECK: SET PICK 0x1, 0x1
+; CHECK: SET PEEK, 0x2
+; CHECK: SET A, PICK 0x1
+; CHECK: IFB A, 0x2
+; CHECK: SET PC, .LBB0_4
+; CHECK: SET PC, .LBB0_1
+; CHECK: :.LBB0_1
+; CHECK: SET A, PEEK
+; CHECK: SET B, PICK 0x1
+; CHECK: IFC A, B
+; CHECK: SET PC, .LBB0_3
+; CHECK: SET PC, .LBB0_2
+; CHECK: :.LBB0_2
+; CHECK: SET PICK 0x2, 0x2
+; CHECK: SET PC, .LBB0_5
+; CHECK: :.LBB0_3
+; CHECK: SET PICK 0x2, 0x1
+; CHECK: SET PC, .LBB0_5
+; CHECK: :.LBB0_4
+; CHECK: SET PICK 0x2, 0x0
+; CHECK: :.LBB0_5
+; CHECK: SET A, PICK 0x2
+; CHECK: ADD SP, 0x3
+; CHECK: SET PC, POP


### PR DESCRIPTION
Some optimisations for AND+IFE 0 cases.
AND+IFE 0 -> IFB
AND+IFN 0 -> IFC

How effective they are I don't know. The optimisations only kick in when it's ensured that the result of the AND is not used past the IFE, because the value is usually put on the stack before jumping and can cause some serious code screwups when landing on a branch due to it pulling the value back off the stack (and so if it isn't there...).
