### PR TITLE
Add isStoreToStackSlot implementation to DCPU16InstrInfo

### DIFF
--- a/lib/Target/DCPU16/DCPU16InstrInfo.cpp
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.cpp
@@ -78,6 +78,19 @@ void DCPU16InstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
     llvm_unreachable("Cannot store this register to stack slot!");
 }
 
+unsigned DCPU16InstrInfo::isStoreToStackSlot(const MachineInstr *MI,
+                                            int &FrameIndex) const {
+  if (MI->getOpcode() == DCPU16::MOV16mr) {
+    if (MI->getOperand(0).isFI()) {
+      // MOV [SP+idx], reg
+      // operand 0 is frame index, 1 is immediate 0, 2 is register
+      FrameIndex = MI->getOperand(0).getIndex();
+      return MI->getOperand(2).getReg();
+    }
+  }
+  return 0;
+}
+
 void DCPU16InstrInfo::copyPhysReg(MachineBasicBlock &MBB,
                                   MachineBasicBlock::iterator I, DebugLoc DL,
                                   unsigned DestReg, unsigned SrcReg,

--- a/lib/Target/DCPU16/DCPU16InstrInfo.h
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.h
@@ -68,6 +68,8 @@ public:
                                     unsigned DestReg, int FrameIdx,
                                     const TargetRegisterClass *RC,
                                     const TargetRegisterInfo *TRI) const;
+  virtual unsigned isStoreToStackSlot(const MachineInstr *MI,
+                                      int &FrameIndex) const;
 
   unsigned GetInstSizeInBytes(const MachineInstr *MI) const;
 


### PR DESCRIPTION
This cures a problem with complex code where various passes of the
register allocator cause redundant spills of registers to the stack to
be generated.  This is normal, and then it iterates over the basic block
calling isStoreToStackSlot to eliminate the redundant ones.  Without this
being implemented, we can generate multiple (useless) consecutive SET
[SP+x], reg instructions.
