### PR TITLE
Generalized a bunch of hardcoded 8-bit byte issues.

### DIFF
--- a/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -5020,7 +5020,7 @@ SDValue DAGCombiner::ReduceLoadWidth(SDNode *N) {
     ShAmt = LVTStoreBits - EVTStoreBits - ShAmt;
   }
 
-  uint64_t PtrOff = ShAmt / 8;
+  uint64_t PtrOff = ShAmt / TLI.getTargetData()->getBitsPerByte();
   unsigned NewAlign = MinAlign(LN0->getAlignment(), PtrOff);
   SDValue NewPtr = DAG.getNode(ISD::ADD, LN0->getDebugLoc(),
                                PtrType, LN0->getBasePtr(),
@@ -5290,7 +5290,9 @@ SDValue DAGCombiner::CombineConsecutiveLoads(SDNode *N, EVT VT) {
       // If one is volatile it might be ok, but play conservative and bail out.
       !LD1->isVolatile() &&
       !LD2->isVolatile() &&
-      DAG.isConsecutiveLoad(LD2, LD1, LD1VT.getSizeInBits()/8, 1)) {
+      DAG.isConsecutiveLoad(LD2, LD1,
+                            LD1VT.getSizeInBits()/TLI.getTargetData()->getBitsPerByte(),
+                            1)) {
     unsigned Align = LD1->getAlignment();
     unsigned NewAlign = TLI.getTargetData()->
       getABITypeAlignment(VT.getTypeForEVT(*DAG.getContext()));
@@ -6727,7 +6729,8 @@ SDValue DAGCombiner::visitLOAD(SDNode *N) {
 /// load is having specific bytes cleared out.  If so, return the byte size
 /// being masked out and the shift amount.
 static std::pair<unsigned, unsigned>
-CheckForMaskedLoad(SDValue V, SDValue Ptr, SDValue Chain) {
+CheckForMaskedLoad(SDValue V, SDValue Ptr, SDValue Chain,
+                   unsigned BitsPerByte) {
   std::pair<unsigned, unsigned> Result(0, 0);
 
   // Check for the structure we're looking for.
@@ -6767,9 +6770,9 @@ CheckForMaskedLoad(SDValue V, SDValue Ptr, SDValue Chain) {
   // follow the sign bit for uniformity.
   uint64_t NotMask = ~cast<ConstantSDNode>(V->getOperand(1))->getSExtValue();
   unsigned NotMaskLZ = CountLeadingZeros_64(NotMask);
-  if (NotMaskLZ & 7) return Result;  // Must be multiple of a byte.
+  if (NotMaskLZ & (BitsPerByte-1)) return Result;  // Must be multiple of a byte.
   unsigned NotMaskTZ = CountTrailingZeros_64(NotMask);
-  if (NotMaskTZ & 7) return Result;  // Must be multiple of a byte.
+  if (NotMaskTZ & (BitsPerByte-1)) return Result;  // Must be multiple of a byte.
   if (NotMaskLZ == 64) return Result;  // All zero mask.
 
   // See if we have a continuous run of bits.  If so, we have 0*1+0*
@@ -6780,7 +6783,8 @@ CheckForMaskedLoad(SDValue V, SDValue Ptr, SDValue Chain) {
   if (V.getValueType() != MVT::i64 && NotMaskLZ)
     NotMaskLZ -= 64-V.getValueSizeInBits();
 
-  unsigned MaskedBytes = (V.getValueSizeInBits()-NotMaskLZ-NotMaskTZ)/8;
+  unsigned MaskedBytes = (V.getValueSizeInBits()-NotMaskLZ-NotMaskTZ) /
+      BitsPerByte;
   switch (MaskedBytes) {
   case 1:
   case 2:
@@ -6790,10 +6794,10 @@ CheckForMaskedLoad(SDValue V, SDValue Ptr, SDValue Chain) {
 
   // Verify that the first bit starts at a multiple of mask so that the access
   // is aligned the same as the access width.
-  if (NotMaskTZ && NotMaskTZ/8 % MaskedBytes) return Result;
+  if (NotMaskTZ && NotMaskTZ/BitsPerByte % MaskedBytes) return Result;
 
   Result.first = MaskedBytes;
-  Result.second = NotMaskTZ/8;
+  Result.second = NotMaskTZ/BitsPerByte;
   return Result;
 }
 
@@ -6812,13 +6816,13 @@ ShrinkLoadReplaceStoreWithStore(const std::pair<unsigned, unsigned> &MaskInfo,
   // Check to see if IVal is all zeros in the part being masked in by the 'or'
   // that uses this.  If not, this is not a replacement.
   APInt Mask = ~APInt::getBitsSet(IVal.getValueSizeInBits(),
-                                  ByteShift*8, (ByteShift+NumBytes)*8);
+                                  ByteShift*BitsPerByte, (ByteShift+NumBytes)*BitsPerByte);
   if (!DAG.MaskedValueIsZero(IVal, Mask)) return 0;
 
   // Check that it is legal on the target to do this.  It is legal if the new
   // VT we're shrinking to (i8/i16/i32) is legal or we're still before type
   // legalization.
-  MVT VT = MVT::getIntegerVT(NumBytes*8);
+  MVT VT = MVT::getIntegerVT(NumBytes*BitsPerByte);
   if (!DC->isTypeLegal(VT))
     return 0;
 
@@ -6826,7 +6830,7 @@ ShrinkLoadReplaceStoreWithStore(const std::pair<unsigned, unsigned> &MaskInfo,
   // shifted by ByteShift and truncated down to NumBytes.
   if (ByteShift)
     IVal = DAG.getNode(ISD::SRL, IVal->getDebugLoc(), IVal.getValueType(), IVal,
-                       DAG.getConstant(ByteShift*8,
+                       DAG.getConstant(ByteShift*BitsPerByte,
                                     DC->getShiftAmountTy(IVal.getValueType())));
 
   // Figure out the offset for the store and the alignment of the access.
@@ -6874,6 +6878,7 @@ SDValue DAGCombiner::ReduceLoadOpStoreWidth(SDNode *N) {
     return SDValue();
 
   unsigned Opc = Value.getOpcode();
+  unsigned BitsPerByte = TLI.getTargetData()->getBitsPerByte();
 
   // If this is "store (or X, Y), P" and X is "(and (load P), cst)", where cst
   // is a byte mask indicating a consecutive number of bytes, check to see if
@@ -6882,8 +6887,7 @@ SDValue DAGCombiner::ReduceLoadOpStoreWidth(SDNode *N) {
   // the load dead.
   if (Opc == ISD::OR) {
     std::pair<unsigned, unsigned> MaskedLoad;
-    MaskedLoad = CheckForMaskedLoad(Value.getOperand(0), Ptr, Chain);
-    unsigned BitsPerByte = TLI.getTargetData()->getBitsPerByte();
+    MaskedLoad = CheckForMaskedLoad(Value.getOperand(0), Ptr, Chain, BitsPerByte);
     if (MaskedLoad.first)
       if (SDNode *NewST = ShrinkLoadReplaceStoreWithStore(MaskedLoad,
                                                           Value.getOperand(1),
@@ -6892,7 +6896,7 @@ SDValue DAGCombiner::ReduceLoadOpStoreWidth(SDNode *N) {
         return SDValue(NewST, 0);
 
     // Or is commutative, so try swapping X and Y.
-    MaskedLoad = CheckForMaskedLoad(Value.getOperand(1), Ptr, Chain);
+    MaskedLoad = CheckForMaskedLoad(Value.getOperand(1), Ptr, Chain, BitsPerByte);
     if (MaskedLoad.first)
       if (SDNode *NewST = ShrinkLoadReplaceStoreWithStore(MaskedLoad,
                                                           Value.getOperand(0),
@@ -6944,11 +6948,11 @@ SDValue DAGCombiner::ReduceLoadOpStoreWidth(SDNode *N) {
       APInt NewImm = (Imm & Mask).lshr(ShAmt).trunc(NewBW);
       if (Opc == ISD::AND)
         NewImm ^= APInt::getAllOnesValue(NewBW);
-      uint64_t PtrOff = ShAmt / 8;
+      uint64_t PtrOff = ShAmt / BitsPerByte;
       // For big endian targets, we need to adjust the offset to the pointer to
       // load the correct bytes.
       if (TLI.isBigEndian())
-        PtrOff = (BitWidth + 7 - NewBW) / 8 - PtrOff;
+        PtrOff = (BitWidth + BitsPerByte-1 - NewBW) / BitsPerByte - PtrOff;
 
       unsigned NewAlign = MinAlign(LD->getAlignment(), PtrOff);
       Type *NewVTTy = NewVT.getTypeForEVT(*DAG.getContext());
@@ -7451,10 +7455,11 @@ SDValue DAGCombiner::visitEXTRACT_VECTOR_ELT(SDNode *N) {
     unsigned PtrOff = 0;
 
     if (Elt) {
-      PtrOff = LVT.getSizeInBits() * Elt / 8;
+      unsigned BitsPerByte = TLI.getTargetData()->getBitsPerByte();
+      PtrOff = LVT.getSizeInBits() * Elt / BitsPerByte;
       EVT PtrType = NewPtr.getValueType();
       if (TLI.isBigEndian())
-        PtrOff = VT.getSizeInBits() / 8 - PtrOff;
+        PtrOff = VT.getSizeInBits() / BitsPerByte - PtrOff;
       NewPtr = DAG.getNode(ISD::ADD, N->getDebugLoc(), PtrType, NewPtr,
                            DAG.getConstant(PtrOff, PtrType));
     }

--- a/lib/CodeGen/SelectionDAG/LegalizeTypesGeneric.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeTypesGeneric.cpp
@@ -131,7 +131,7 @@ void DAGTypeLegalizer::ExpandRes_BITCAST(SDNode *N, SDValue &Lo, SDValue &Hi) {
                    false, false, false, 0);
 
   // Increment the pointer to the other half.
-  unsigned IncrementSize = NOutVT.getSizeInBits() / 8;
+  unsigned IncrementSize = NOutVT.getSizeInBits() / TLI.getTargetData()->getBitsPerByte();
   StackPtr = DAG.getNode(ISD::ADD, dl, StackPtr.getValueType(), StackPtr,
                          DAG.getIntPtrConstant(IncrementSize));
 
@@ -218,7 +218,7 @@ void DAGTypeLegalizer::ExpandRes_NormalLoad(SDNode *N, SDValue &Lo,
                    isVolatile, isNonTemporal, isInvariant, Alignment);
 
   // Increment the pointer to the other half.
-  unsigned IncrementSize = NVT.getSizeInBits() / 8;
+  unsigned IncrementSize = NVT.getSizeInBits() / TLI.getTargetData()->getBitsPerByte();
   Ptr = DAG.getNode(ISD::ADD, dl, Ptr.getValueType(), Ptr,
                     DAG.getIntPtrConstant(IncrementSize));
   Hi = DAG.getLoad(NVT, dl, Chain, Ptr,
@@ -398,7 +398,7 @@ SDValue DAGTypeLegalizer::ExpandOp_NormalStore(SDNode *N, unsigned OpNo) {
   bool isNonTemporal = St->isNonTemporal();
 
   assert(NVT.isByteSized() && "Expanded type not byte sized!");
-  unsigned IncrementSize = NVT.getSizeInBits() / 8;
+  unsigned IncrementSize = NVT.getSizeInBits() / TLI.getTargetData()->getBitsPerByte();
 
   SDValue Lo, Hi;
   GetExpandedOp(St->getValue(), Lo, Hi);

--- a/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -28,6 +28,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CodeGen/SelectionDAG.h"
+#include "llvm/Target/TargetData.h"
 #include "llvm/Target/TargetLowering.h"
 using namespace llvm;
 
@@ -305,7 +306,7 @@ SDValue VectorLegalizer::ExpandLoad(SDValue Op) {
   SmallVector<SDValue, 8> LoadVals;
   SmallVector<SDValue, 8> LoadChains;
   unsigned NumElem = SrcVT.getVectorNumElements();
-  unsigned Stride = SrcVT.getScalarType().getSizeInBits()/8;
+  unsigned Stride = SrcVT.getScalarType().getSizeInBits()/TLI.getTargetData()->getBitsPerByte();
 
   for (unsigned Idx=0; Idx<NumElem; Idx++) {
     SDValue ScalarLoad = DAG.getExtLoad(ExtType, dl,
@@ -360,7 +361,7 @@ SDValue VectorLegalizer::ExpandStore(SDValue Op) {
     ScalarSize = NextPowerOf2(ScalarSize);
 
   // Store Stride in bytes
-  unsigned Stride = ScalarSize/8;
+  unsigned Stride = ScalarSize/TLI.getTargetData()->getBitsPerByte();
   // Extract each of the elements from the original vector
   // and save them into memory individually.
   SmallVector<SDValue, 8> Stores;

--- a/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -717,7 +717,7 @@ void DAGTypeLegalizer::SplitVecRes_INSERT_VECTOR_ELT(SDNode *N, SDValue &Lo,
                    false, false, false, 0);
 
   // Increment the pointer to the other part.
-  unsigned IncrementSize = Lo.getValueType().getSizeInBits() / 8;
+  unsigned IncrementSize = Lo.getValueType().getSizeInBits() / TLI.getTargetData()->getBitsPerByte();
   StackPtr = DAG.getNode(ISD::ADD, dl, StackPtr.getValueType(), StackPtr,
                          DAG.getIntPtrConstant(IncrementSize));
 
@@ -759,7 +759,7 @@ void DAGTypeLegalizer::SplitVecRes_LOAD(LoadSDNode *LD, SDValue &Lo,
                    LD->getPointerInfo(), LoMemVT, isVolatile, isNonTemporal,
                    isInvariant, Alignment);
 
-  unsigned IncrementSize = LoMemVT.getSizeInBits()/8;
+  unsigned IncrementSize = LoMemVT.getSizeInBits()/TLI.getTargetData()->getBitsPerByte();
   Ptr = DAG.getNode(ISD::ADD, dl, Ptr.getValueType(), Ptr,
                     DAG.getIntPtrConstant(IncrementSize));
   Hi = DAG.getLoad(ISD::UNINDEXED, ExtType, HiVT, dl, Ch, Ptr, Offset,
@@ -1127,7 +1127,7 @@ SDValue DAGTypeLegalizer::SplitVecOp_STORE(StoreSDNode *N, unsigned OpNo) {
   EVT LoMemVT, HiMemVT;
   GetSplitDestVTs(MemoryVT, LoMemVT, HiMemVT);
 
-  unsigned IncrementSize = LoMemVT.getSizeInBits()/8;
+  unsigned IncrementSize = LoMemVT.getSizeInBits()/TLI.getTargetData()->getBitsPerByte();
 
   if (isTruncating)
     Lo = DAG.getTruncStore(Ch, DL, Lo, Ptr, N->getPointerInfo(),
@@ -2223,7 +2223,7 @@ static EVT FindMemType(SelectionDAG& DAG, const TargetLowering &TLI,
   EVT WidenEltVT = WidenVT.getVectorElementType();
   unsigned WidenWidth = WidenVT.getSizeInBits();
   unsigned WidenEltWidth = WidenEltVT.getSizeInBits();
-  unsigned AlignInBits = Align*8;
+  unsigned AlignInBits = Align*TLI.getTargetData()->getBitsPerByte();
 
   // If we have one element to load/store, return it.
   EVT RetVT = WidenEltVT;
@@ -2360,7 +2360,7 @@ SDValue DAGTypeLegalizer::GenWidenVectorLoads(SmallVector<SDValue, 16> &LdChain,
   unsigned Offset = 0;
 
   while (LdWidth > 0) {
-    unsigned Increment = NewVTWidth / 8;
+    unsigned Increment = NewVTWidth / TLI.getTargetData()->getBitsPerByte();
     Offset += Increment;
     BasePtr = DAG.getNode(ISD::ADD, dl, BasePtr.getValueType(), BasePtr,
                           DAG.getIntPtrConstant(Increment));
@@ -2478,7 +2478,7 @@ DAGTypeLegalizer::GenWidenVectorExtLoads(SmallVector<SDValue, 16>& LdChain,
   // Load each element and widen
   unsigned WidenNumElts = WidenVT.getVectorNumElements();
   SmallVector<SDValue, 16> Ops(WidenNumElts);
-  unsigned Increment = LdEltVT.getSizeInBits() / 8;
+  unsigned Increment = LdEltVT.getSizeInBits() / TLI.getTargetData()->getBitsPerByte();
   Ops[0] = DAG.getExtLoad(ExtType, dl, EltVT, Chain, BasePtr,
                           LD->getPointerInfo(),
                           LdEltVT, isVolatile, isNonTemporal, Align);
@@ -2529,7 +2529,7 @@ void DAGTypeLegalizer::GenWidenVectorStores(SmallVector<SDValue, 16>& StChain,
     // Find the largest vector type we can store with
     EVT NewVT = FindMemType(DAG, TLI, StWidth, ValVT);
     unsigned NewVTWidth = NewVT.getSizeInBits();
-    unsigned Increment = NewVTWidth / 8;
+    unsigned Increment = NewVTWidth / TLI.getTargetData()->getBitsPerByte();
     if (NewVT.isVector()) {
       unsigned NumVTElts = NewVT.getVectorNumElements();
       do {
@@ -2596,7 +2596,7 @@ DAGTypeLegalizer::GenWidenVectorTruncStores(SmallVector<SDValue, 16>& StChain,
   // the store.
   EVT StEltVT  = StVT.getVectorElementType();
   EVT ValEltVT = ValVT.getVectorElementType();
-  unsigned Increment = ValEltVT.getSizeInBits() / 8;
+  unsigned Increment = ValEltVT.getSizeInBits() / TLI.getTargetData()->getBitsPerByte();
   unsigned NumElts = StVT.getVectorNumElements();
   SDValue EOp = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, ValEltVT, ValOp,
                             DAG.getIntPtrConstant(0));

--- a/test/CodeGen/DCPU16/i32mem.ll
+++ b/test/CodeGen/DCPU16/i32mem.ll
@@ -1,0 +1,25 @@
+; RUN: llc < %s -march=dcpu16 | FileCheck %s
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
+target triple = "dcpu16"
+
+define void @storei32(i32* nocapture %a, i32 %b) nounwind {
+entry:
+  store i32 %b, i32* %a, align 1, !tbaa !0
+  ret void
+}
+
+; CHECK: SET [0x1+A], C
+; CHECK: SET [A], B
+
+define i32 @loadi32(i32* nocapture %a) nounwind readonly {
+entry:
+  %0 = load i32* %a, align 1, !tbaa !0
+  ret i32 %0
+}
+
+!0 = metadata !{metadata !"int", metadata !1}
+!1 = metadata !{metadata !"omnipotent char", metadata !2}
+!2 = metadata !{metadata !"Simple C/C++ TBAA"}
+
+; CHECK: SET C, [A]
+; CHECK: SET B, [0x1+A]


### PR DESCRIPTION
This fixes, for example, 32-bit loads and stores going to [index+0] and
[index+2].  Added tests for that case.
