### PR TITLE
Change some ASM pseudo ops to be compatible with binutils

### DIFF
--- a/lib/MC/MCObjectFileInfo.cpp
+++ b/lib/MC/MCObjectFileInfo.cpp
@@ -396,6 +396,10 @@ void MCObjectFileInfo::InitELFMCObjectFileInfo(Triple T) {
 
 
 void MCObjectFileInfo::InitCOFFMCObjectFileInfo(Triple T) {
+  // .comm doesn't support alignment on the DCPU16.
+  if (T.getArch() == Triple::dcpu16)
+    CommDirectiveSupportsAlignment = false;
+
   // COFF
   TextSection =
     Ctx->getCOFFSection(".text",
@@ -558,9 +562,10 @@ void MCObjectFileInfo::InitMCObjectFileInfo(StringRef TT, Reloc::Model relocm,
       (T.isOSDarwin() || T.getEnvironment() == Triple::MachO)) {
     Env = IsMachO;
     InitMachOMCObjectFileInfo(T);
-  } else if ((Arch == Triple::x86 || Arch == Triple::x86_64) &&
-             (T.getOS() == Triple::MinGW32 || T.getOS() == Triple::Cygwin ||
-              T.getOS() == Triple::Win32)) {
+  } else if (((Arch == Triple::x86 || Arch == Triple::x86_64) &&
+              (T.getOS() == Triple::MinGW32 || T.getOS() == Triple::Cygwin ||
+               T.getOS() == Triple::Win32)) ||
+             Arch == Triple::dcpu16) {
     Env = IsCOFF;
     InitCOFFMCObjectFileInfo(T);
   } else {

--- a/lib/Target/DCPU16/MCTargetDesc/DCPU16MCAsmInfo.cpp
+++ b/lib/Target/DCPU16/MCTargetDesc/DCPU16MCAsmInfo.cpp
@@ -34,4 +34,7 @@ DCPU16MCAsmInfo::DCPU16MCAsmInfo(const Target &T, StringRef TT) {
   AllowNameToStartWithDigit = true;
   UsesELFSectionDirectiveForBSS = false;
   HasDotTypeDotSizeDirective = false;
+
+  // Use .lcomm instead of .local .comm (required for binutils support)
+  LCOMMDirectiveType = LCOMM::NoAlignment;
 }

--- a/test/CodeGen/DCPU16/comm.ll
+++ b/test/CodeGen/DCPU16/comm.ll
@@ -1,0 +1,25 @@
+; RUN: llc < %s -march=dcpu16 | FileCheck %s
+target datalayout = "e-p:16:16:16-i8:16:16-i16:16:16-i32:16:16-s0:16:16-n16"
+target triple = "dcpu16"
+
+@static_int = internal unnamed_addr global i16 0, align 1
+@global_int = common global i16 0, align 1
+
+define void @set_val(i16 %val) nounwind {
+entry:
+  store i16 %val, i16* @static_int, align 1
+  store i16 %val, i16* @global_int, align 1
+  ret void
+}
+
+define void @get_val(i16* nocapture %global_val, i16* nocapture %static_val) nounwind {
+entry:
+  %0 = load i16* @static_int, align 1
+  store i16 %0, i16* %static_val, align 1
+  %1 = load i16* @global_int, align 1
+  store i16 %1, i16* %global_val, align 1
+  ret void
+}
+
+; CHECK: .lcomm static_int,1
+; CHECK: .comm  global_int,1


### PR DESCRIPTION
- .comm doesn't support alignment (not needed for DCPU anyways)
- .local .comm is not supported, use .lcomm instead
