### PR TITLE
Use "SET PC, ..." instead of "SET pc, ..." in indirect branch instructions

### DIFF
--- a/lib/Target/DCPU16/DCPU16InstrInfo.td
+++ b/lib/Target/DCPU16/DCPU16InstrInfo.td
@@ -196,10 +196,10 @@ let isBarrier = 1 in {
                     "br\t$brdst",
                     [(brind tblockaddress:$brdst)]>;
     def Br  : I16rr<0, (outs), (ins GEXR16:$brdst),
-                    "SET\t{pc, $brdst}",
+                    "SET\t{PC, $brdst}",
                     [(brind GEXR16:$brdst)]>;
     def Bm  : I16rm<0, (outs), (ins memsrc:$brdst),
-                    "SET\t{pc, $brdst}",
+                    "SET\t{PC, $brdst}",
                     [(brind (load addr:$brdst))]>;
   }
 }


### PR DESCRIPTION
The binutils assembler generates a reference to the "pc" symbol instead of the PC register.  We need to be consistent with our register name case here.
